### PR TITLE
fix authorize

### DIFF
--- a/fulcra_api/core.py
+++ b/fulcra_api/core.py
@@ -133,7 +133,7 @@ class FulcraAPI:
                 display(HTML("<p>Your access token is still valid.</p>"))
             else:
                 print("Your access token is still valid.")
-            return self.fulcra_cached_access_token
+            return
         device_code, uri, code = self._request_device_code(
             FULCRA_AUTH0_DOMAIN,
             FULCRA_AUTH0_CLIENT_ID,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fulcra-api"
-version = "0.1.11"
+version = "0.1.12"
 description = ""
 authors = ["Brandon Creighton <brandon@fulcradynamics.com>"]
 readme = "README.md"


### PR DESCRIPTION
`authorize` shouldn't return the token.  In many cases, the user won't actually need to see it or interact with it directly.  Also, if it's being returned, then there's a risk of it inadvertently ending up in notebook output and being saved / leaked.