### PR TITLE
Add Fulcra Annotation support

### DIFF
--- a/examples/auth_code_flow_app/app.py
+++ b/examples/auth_code_flow_app/app.py
@@ -1,6 +1,6 @@
 from flask import Flask, redirect, request, url_for, session, render_template_string
 from fulcra_api.core import FulcraAPI
-import json # For pretty printing the metrics catalog
+import json  # For pretty printing the metrics catalog
 
 # Configuration
 # IMPORTANT: This redirect URI must be added to your Auth0 application's
@@ -15,13 +15,13 @@ CUSTOM_OIDC_AUDIENCE = None
 app = Flask(__name__)
 # It's important to set a secret key for session management in Flask.
 # In a real application, use a strong, randomly generated key and keep it secret.
-app.secret_key = "your_very_secret_key_here_change_me" 
+app.secret_key = "your_very_secret_key_here_change_me"
 
 fulcra_client = FulcraAPI(
     oidc_domain=CUSTOM_OIDC_DOMAIN,
     oidc_client_id=CUSTOM_OIDC_CLIENT_ID,
     oidc_scope=CUSTOM_OIDC_SCOPE,
-    oidc_audience=CUSTOM_OIDC_AUDIENCE
+    oidc_audience=CUSTOM_OIDC_AUDIENCE,
 )
 
 # HTML Templates (in-line for simplicity)
@@ -66,57 +66,69 @@ ERROR_TEMPLATE = """
 </html>
 """
 
-@app.route('/')
+
+@app.route("/")
 def home():
-    fulcra_userid = session.get('fulcra_userid')
+    fulcra_userid = session.get("fulcra_userid")
     return render_template_string(HOME_TEMPLATE, fulcra_userid=fulcra_userid)
 
-@app.route('/login')
+
+@app.route("/login")
 def login():
     # Generate the authorization URL
     authorization_url = fulcra_client.get_authorization_code_url(
         redirect_uri=REDIRECT_URI,
-        state="some_random_state_string" # Optional: for CSRF protection
+        state="some_random_state_string",  # Optional: for CSRF protection
     )
     # Redirect the user to the authorization URL
     return redirect(authorization_url)
 
-@app.route('/callback')
+
+@app.route("/callback")
 def callback():
     # Auth0 will redirect the user here after authentication
-    error = request.args.get('error')
+    error = request.args.get("error")
     if error:
-        error_description = request.args.get('error_description', 'No description provided.')
-        return render_template_string(ERROR_TEMPLATE, error_message=f"Auth0 Error: {error} - {error_description}")
+        error_description = request.args.get(
+            "error_description", "No description provided."
+        )
+        return render_template_string(
+            ERROR_TEMPLATE, error_message=f"Auth0 Error: {error} - {error_description}"
+        )
 
-    code = request.args.get('code')
+    code = request.args.get("code")
     # Optional: Verify state parameter here if you sent one
     # received_state = request.args.get('state')
     # if received_state != "some_random_state_string":
     #     return render_template_string(ERROR_TEMPLATE, error_message="State mismatch. Possible CSRF attack.")
 
     if not code:
-        return render_template_string(ERROR_TEMPLATE, error_message="Authorization code not found in callback.")
+        return render_template_string(
+            ERROR_TEMPLATE, error_message="Authorization code not found in callback."
+        )
 
     try:
         # Exchange the authorization code for an access token
         fulcra_client.authorize_with_authorization_code(
-            code=code,
-            redirect_uri=REDIRECT_URI
+            code=code, redirect_uri=REDIRECT_URI
         )
         # Store token info or user identifier in session if needed for subsequent requests
         # For this demo, FulcraAPI caches the token internally.
         # We can store the user ID for display purposes.
-        session['fulcra_userid'] = fulcra_client.get_fulcra_userid()
-        return redirect(url_for('metrics'))
+        session["fulcra_userid"] = fulcra_client.get_fulcra_userid()
+        return redirect(url_for("metrics"))
     except Exception as e:
-        return render_template_string(ERROR_TEMPLATE, error_message=f"Failed to exchange authorization code for token: {str(e)}")
+        return render_template_string(
+            ERROR_TEMPLATE,
+            error_message=f"Failed to exchange authorization code for token: {str(e)}",
+        )
 
-@app.route('/metrics')
+
+@app.route("/metrics")
 def metrics():
     if not fulcra_client.fulcra_cached_access_token:
-        return redirect(url_for('login'))
-    
+        return redirect(url_for("login"))
+
     try:
         # Make an API call
         metrics_data = fulcra_client.metrics_catalog()
@@ -128,32 +140,44 @@ def metrics():
                 refreshed = fulcra_client.refresh_access_token()
                 if refreshed:
                     metrics_data = fulcra_client.metrics_catalog()
-                    return render_template_string(METRICS_TEMPLATE, metrics_data=metrics_data)
+                    return render_template_string(
+                        METRICS_TEMPLATE, metrics_data=metrics_data
+                    )
                 else:
                     # Clear session and redirect to login if refresh fails
-                    session.pop('fulcra_userid', None)
+                    session.pop("fulcra_userid", None)
                     fulcra_client.fulcra_cached_access_token = None
                     fulcra_client.fulcra_cached_refresh_token = None
                     fulcra_client.fulcra_cached_access_token_expiration = None
-                    return render_template_string(ERROR_TEMPLATE, error_message=f"Failed to refresh token. Please login again. Original error: {str(e)}")
+                    return render_template_string(
+                        ERROR_TEMPLATE,
+                        error_message=f"Failed to refresh token. Please login again. Original error: {str(e)}",
+                    )
             except Exception as refresh_e:
-                session.pop('fulcra_userid', None)
+                session.pop("fulcra_userid", None)
                 fulcra_client.fulcra_cached_access_token = None
                 fulcra_client.fulcra_cached_refresh_token = None
                 fulcra_client.fulcra_cached_access_token_expiration = None
-                return render_template_string(ERROR_TEMPLATE, error_message=f"Error during token refresh: {str(refresh_e)}. Please login again.")
-        
-        session.pop('fulcra_userid', None)
+                return render_template_string(
+                    ERROR_TEMPLATE,
+                    error_message=f"Error during token refresh: {str(refresh_e)}. Please login again.",
+                )
+
+        session.pop("fulcra_userid", None)
         fulcra_client.fulcra_cached_access_token = None
         fulcra_client.fulcra_cached_refresh_token = None
         fulcra_client.fulcra_cached_access_token_expiration = None
-        return render_template_string(ERROR_TEMPLATE, error_message=f"API call failed: {str(e)}. Please login again.")
+        return render_template_string(
+            ERROR_TEMPLATE,
+            error_message=f"API call failed: {str(e)}. Please login again.",
+        )
 
-@app.route('/logout')
+
+@app.route("/logout")
 def logout():
     # Clear session data
-    session.pop('fulcra_userid', None)
-    
+    session.pop("fulcra_userid", None)
+
     # Clear cached tokens in FulcraAPI client
     # Note: This is a client-side logout. For a full Auth0 logout,
     # you would redirect to the Auth0 logout endpoint.
@@ -161,17 +185,18 @@ def logout():
     fulcra_client.fulcra_cached_access_token = None
     fulcra_client.fulcra_cached_refresh_token = None
     fulcra_client.fulcra_cached_access_token_expiration = None
-    
+
     # For a full Single Sign-Out (SSO) with an OIDC provider like Auth0, you'd redirect to:
     # client_id = fulcra_client.oidc_client_id # Use instance specific client_id
     # return_to_url = url_for('home', _external=True)
     # oidc_domain = fulcra_client.oidc_domain # Use instance specific domain
     # logout_url = f"https://{oidc_domain}/v2/logout?client_id={client_id}&returnTo={return_to_url}" # Path might vary by provider
     # return redirect(logout_url)
-    
-    return redirect(url_for('home'))
 
-if __name__ == '__main__':
+    return redirect(url_for("home"))
+
+
+if __name__ == "__main__":
     # Make sure to run with HTTPS if deploying, for security of tokens.
     # For local development, HTTP is often fine but be aware of risks.
     # Flask's dev server is not for production. Use a proper WSGI server like Gunicorn.

--- a/examples/auth_code_flow_app/app.py
+++ b/examples/auth_code_flow_app/app.py
@@ -1,6 +1,6 @@
-from flask import Flask, redirect, request, url_for, session, render_template_string
+from flask import Flask, redirect, render_template_string, request, session, url_for
+
 from fulcra_api.core import FulcraAPI
-import json  # For pretty printing the metrics catalog
 
 # Configuration
 # IMPORTANT: This redirect URI must be added to your Auth0 application's

--- a/fulcra_api/core.py
+++ b/fulcra_api/core.py
@@ -668,63 +668,6 @@ class FulcraAPI:
         )
         return json.loads(resp)
 
-    def simple_events(
-        self,
-        start_time: Union[str, datetime.datetime],
-        end_time: Union[str, datetime.datetime],
-        categories: Optional[List[str]] = None,
-        fulcra_userid: Optional[str] = None,
-    ) -> List[Dict]:
-        """
-        Retrieve the events that occurred during the specified period of time,
-        optionally filtering by categories.
-
-        If included, the `categories` parameter only includes events from the specified
-        categories.
-
-        Requires an authorized access token.
-
-        Params:
-            start_time: The start of the time range (inclusive), as an ISO 8601 string or `datetime` object.
-            end_time: The end of the range (exclusive), as an ISO 8601 string or `datetime` object.
-            categories:
-                When present, the categories to filter on.  Only events
-                matching these categories will be returned.
-            fulcra_userid: When present, specifies the Fulcra user ID to request data for.
-
-        Returns:
-            A list of dicts, each of which represents an event.
-
-        Examples:
-            To retrieve the stored events during a given range:
-
-            >>> simple_events = fulcra.simple_events(
-            ...     start_time="2022-05-01 04:00:00.000Z",
-            ...     end_time="2023-08-03 04:00:00.000Z"
-            ... )
-
-            To get the details of an event:
-            >>> simple_events[0]
-            {'event_body': 'relieved', 'category': 'mood', 'event_id':
-            '12680011-6668-4c8e-b4cd-3ca429445ac0', 'timestamp':
-            '2022-09-21T05:51:22Z'}
-
-        """
-        params = {
-            "start_time": start_time,
-            "end_time": end_time,
-        }
-        if categories is not None:
-            params["categories"] = categories
-        qparams = urllib.parse.urlencode(params, doseq=True)
-        if fulcra_userid is None:
-            fulcra_userid = self.get_fulcra_userid()
-        resp = self.fulcra_api(
-            self.fulcra_cached_access_token,
-            f"/data/v0/{fulcra_userid}/simple_events?{qparams}",
-        )
-        return json.loads(resp)
-
     def metric_samples(
         self,
         start_time: Union[str, datetime.datetime],

--- a/fulcra_api/core.py
+++ b/fulcra_api/core.py
@@ -386,6 +386,26 @@ class FulcraAPI:
             raise Exception(f"request failed: {response.read().decode('utf-8')}")
         return response.read()
 
+    def fulcra_v1_api(
+        self, access_token: str, data_class: str, data_type: str, params: dict = {}
+    ) -> bytes:
+        """
+        Make a call to the v1 API.
+
+        Params:
+            access_token: The access token to authenticate the request with
+            data_class: The class of data to query (event or metric)
+            data_type: The data type to query
+            params: Additional params to add to the query
+
+        Returns:
+            The raw response data (as bytes).  Raises an exception on failure.
+        """
+        query_params = urllib.parse.urlencode(params, doseq=True)
+        return self.fulcra_api(
+            access_token, f"/data/v1alpha1/{data_class}/{data_type}?{query_params}"
+        )
+
     def get_fulcra_userid(self) -> str:
         """
         Retrieve the currently authorized Fulcra UserID.
@@ -1090,43 +1110,6 @@ class FulcraAPI:
         )
         return json.loads(resp)
 
-    def custom_input_events(
-        self,
-        start_time: Union[str, datetime.datetime],
-        end_time: Union[str, datetime.datetime],
-        source: Optional[str] = None,
-        fulcra_userid: Optional[str] = None,
-    ) -> List[Dict]:
-        """
-        Retrieves events from Fulcra custom inputs, along with any metadata,
-        for the requested time ranges.
-
-        Requires a valid access token.
-
-        Params:
-            start_time: The start of the time range (inclusive), as an ISO 8601 string or `datetime` object
-            end_time: The end of the range (exclusive), as an ISO 8601 string or `datetime` object
-            source: When specified, the full name of the source to query records from
-            fulcra_userid: When present, specifies the Fulcra user ID to request data for
-
-        Returns:
-            A list of events; each event is represnted by a dict.
-        """
-        params = {
-            "start_time": start_time,
-            "end_time": end_time,
-        }
-        if source is not None:
-            params["source"] = source
-        if fulcra_userid is not None:
-            params["fulcra_userid"] = fulcra_userid
-        qparams = urllib.parse.urlencode(params, doseq=True)
-        resp = self.fulcra_api(
-            self.fulcra_cached_access_token,
-            f"/data/v1alpha1/type/CustomInputEvent?{qparams}",
-        )
-        return json.loads(resp)
-
     def get_shared_datasets(self) -> List[Dict]:
         """
         Retrieves datasets that have been shared with the currently authenticated user
@@ -1369,3 +1352,223 @@ class FulcraAPI:
             f"/data/v0/{fulcra_userid}/sleep_agg?{qparams}",
         )
         return pd.read_feather(io.BytesIO(resp))
+
+    def moment_annotations(
+        self,
+        start_time: Union[str, datetime.datetime],
+        end_time: Union[str, datetime.datetime],
+        source: Optional[str] = None,
+        fulcra_userid: Optional[str] = None,
+    ) -> List[Dict]:
+        """
+        Retrieves recorded Moment Annotations, along with any metadata, for the requested time ranges.
+
+        Requires a valid access token.
+
+        Params:
+            start_time: The start of the time range (inclusive), as an ISO 8601 string or `datetime` object
+            end_time: The end of the range (exclusive), as an ISO 8601 string or `datetime` object
+            source: When specified, the full identifier of the source to query records from
+            fulcra_userid: When present, specifies the Fulcra user ID to request data for
+
+        Returns:
+            A list of recorded annotations; each annotation is represented by a dict.
+
+        """
+        params = {}
+
+        params["start_time"] = start_time
+        params["end_time"] = end_time
+
+        if fulcra_userid is not None:
+            params["fulcra_userid"] = fulcra_userid
+
+        if "filter" not in params:
+            params["filter"] = []
+
+        if source is not None:
+            params["filter"].append(f"source_id:{source}")
+
+        resp = self.fulcra_v1_api(
+            self.fulcra_cached_access_token,
+            "event",
+            "MomentAnnotation",
+            params,
+        )
+        return json.loads(resp)
+
+    def duration_annotations(
+        self,
+        start_time: Union[str, datetime.datetime],
+        end_time: Union[str, datetime.datetime],
+        source: Optional[str] = None,
+        fulcra_userid: Optional[str] = None,
+    ) -> List[Dict]:
+        """
+        Retrieves recorded Duration Annotations, along with any metadata, for the requested time ranges.
+
+        Requires a valid access token.
+
+        Params:
+            start_time: The start of the time range (inclusive), as an ISO 8601 string or `datetime` object
+            end_time: The end of the range (exclusive), as an ISO 8601 string or `datetime` object
+            source: When specified, the full identifier of the source to query records from
+            fulcra_userid: When present, specifies the Fulcra user ID to request data for
+
+        Returns:
+            A list of recorded annotations; each annotation is represented by a dict.
+
+        """
+        params = {}
+
+        params["start_time"] = start_time
+        params["end_time"] = end_time
+
+        if fulcra_userid is not None:
+            params["fulcra_userid"] = fulcra_userid
+
+        if "filter" not in params:
+            params["filter"] = []
+
+        if source is not None:
+            params["filter"].append(f"source_id:{source}")
+
+        resp = self.fulcra_v1_api(
+            self.fulcra_cached_access_token,
+            "event",
+            "DurationAnnotation",
+            params,
+        )
+        return json.loads(resp)
+
+    def boolean_annotations(
+        self,
+        start_time: Union[str, datetime.datetime],
+        end_time: Union[str, datetime.datetime],
+        source: Optional[str] = None,
+        fulcra_userid: Optional[str] = None,
+    ) -> List[Dict]:
+        """
+        Retrieves recorded Boolean Annotations, along with any metadata, for the requested time ranges.
+
+        Requires a valid access token.
+
+        Params:
+            start_time: The start of the time range (inclusive), as an ISO 8601 string or `datetime` object
+            end_time: The end of the range (exclusive), as an ISO 8601 string or `datetime` object
+            source: When specified, the full identifier of the source to query records from
+            fulcra_userid: When present, specifies the Fulcra user ID to request data for
+
+        Returns:
+            A list of recorded annotations; each annotation is represented by a dict.
+
+        """
+        params = {}
+
+        params["start_time"] = start_time
+        params["end_time"] = end_time
+
+        if fulcra_userid is not None:
+            params["fulcra_userid"] = fulcra_userid
+
+        if "filter" not in params:
+            params["filter"] = []
+
+        if source is not None:
+            params["filter"].append(f"source_id:{source}")
+
+        resp = self.fulcra_v1_api(
+            self.fulcra_cached_access_token,
+            "metric",
+            "BooleanAnnotation",
+            params,
+        )
+        return json.loads(resp)
+
+    def numeric_annotations(
+        self,
+        start_time: Union[str, datetime.datetime],
+        end_time: Union[str, datetime.datetime],
+        source: Optional[str] = None,
+        fulcra_userid: Optional[str] = None,
+    ) -> List[Dict]:
+        """
+        Retrieves recorded Numeric Annotations, along with any metadata, for the requested time ranges.
+
+        Requires a valid access token.
+
+        Params:
+            start_time: The start of the time range (inclusive), as an ISO 8601 string or `datetime` object
+            end_time: The end of the range (exclusive), as an ISO 8601 string or `datetime` object
+            source: When specified, the full identifier of the source to query records from
+            fulcra_userid: When present, specifies the Fulcra user ID to request data for
+
+        Returns:
+            A list of recorded annotations; each annotation is represented by a dict.
+
+        """
+        params = {}
+
+        params["start_time"] = start_time
+        params["end_time"] = end_time
+
+        if fulcra_userid is not None:
+            params["fulcra_userid"] = fulcra_userid
+
+        if "filter" not in params:
+            params["filter"] = []
+
+        if source is not None:
+            params["filter"].append(f"source_id:{source}")
+
+        resp = self.fulcra_v1_api(
+            self.fulcra_cached_access_token,
+            "metric",
+            "NumericAnnotation",
+            params,
+        )
+        return json.loads(resp)
+
+    def scale_annotations(
+        self,
+        start_time: Union[str, datetime.datetime],
+        end_time: Union[str, datetime.datetime],
+        source: Optional[str] = None,
+        fulcra_userid: Optional[str] = None,
+    ) -> List[Dict]:
+        """
+        Retrieves recorded Scale Annotations, along with any metadata, for the requested time ranges.
+
+        Requires a valid access token.
+
+        Params:
+            start_time: The start of the time range (inclusive), as an ISO 8601 string or `datetime` object
+            end_time: The end of the range (exclusive), as an ISO 8601 string or `datetime` object
+            source: When specified, the full identifier of the source to query records from
+            fulcra_userid: When present, specifies the Fulcra user ID to request data for
+
+        Returns:
+            A list of recorded annotations; each annotation is represented by a dict.
+
+        """
+        params = {}
+
+        params["start_time"] = start_time
+        params["end_time"] = end_time
+
+        if fulcra_userid is not None:
+            params["fulcra_userid"] = fulcra_userid
+
+        if "filter" not in params:
+            params["filter"] = []
+
+        if source is not None:
+            params["filter"].append(f"source_id:{source}")
+
+        resp = self.fulcra_v1_api(
+            self.fulcra_cached_access_token,
+            "metric",
+            "ScaleAnnotation",
+            params,
+        )
+        return json.loads(resp)

--- a/fulcra_api/core.py
+++ b/fulcra_api/core.py
@@ -129,7 +129,7 @@ class FulcraAPI:
         data = json.loads(response.read())
         if "access_token" not in data:
             return (None, None, None)
-        
+
         access_token = data["access_token"]
         expires_in = datetime.datetime.now() + datetime.timedelta(
             seconds=float(data["expires_in"])
@@ -264,7 +264,7 @@ class FulcraAPI:
         }
         if state:
             params["state"] = state
-        
+
         return f"https://{self.oidc_domain}/authorize?{urllib.parse.urlencode(params)}"
 
     def set_cached_access_token(self, token: str):
@@ -307,8 +307,10 @@ class FulcraAPI:
             "code": code,
             "redirect_uri": redirect_uri,
         }
-        
-        access_token, expiration_date, refresh_token = self._fetch_token_from_auth_server(payload)
+
+        access_token, expiration_date, refresh_token = (
+            self._fetch_token_from_auth_server(payload)
+        )
 
         if access_token and expiration_date:
             self.fulcra_cached_access_token = access_token
@@ -330,7 +332,7 @@ class FulcraAPI:
 
         Returns:
             True if the token was successfully refreshed, False otherwise.
-        
+
         Raises:
             Exception: If no refresh token is available.
         """
@@ -344,7 +346,9 @@ class FulcraAPI:
             "scope": self.oidc_scope,
         }
 
-        access_token, expiration_date, new_refresh_token = self._fetch_token_from_auth_server(payload)
+        access_token, expiration_date, new_refresh_token = (
+            self._fetch_token_from_auth_server(payload)
+        )
 
         if access_token and expiration_date:
             self.fulcra_cached_access_token = access_token
@@ -806,7 +810,7 @@ class FulcraAPI:
         params = {"start_time": start_time, "end_time": end_time}
         if fulcra_source_id is not None:
             params["fulcra_source_id"] = fulcra_source_id
-        
+
         qparams = urllib.parse.urlencode(params, doseq=True)
         if fulcra_userid is None:
             fulcra_userid = self.get_fulcra_userid()
@@ -1408,7 +1412,7 @@ class FulcraAPI:
         if agg_functions is not None:
             params["agg_functions"] = agg_functions
         else:
-            params["agg_functions"] = ["sum"] # Default as per OpenAPI if not provided
+            params["agg_functions"] = ["sum"]  # Default as per OpenAPI if not provided
         if tz is not None:
             params["tz"] = tz
 

--- a/fulcra_api/core.py
+++ b/fulcra_api/core.py
@@ -1,13 +1,14 @@
-import http.client
-import urllib.parse
-import json
 import base64
 import datetime
-import time
-import pandas as pd
-from typing import List, Tuple, Dict, Optional, Union
+import http.client
 import io
+import json
+import time
+import urllib.parse
 import webbrowser
+from typing import Dict, List, Optional, Tuple, Union
+
+import pandas as pd
 
 try:
     from IPython.display import HTML, display
@@ -487,7 +488,7 @@ class FulcraAPI:
             "metrics": metrics,
             "output": "arrow",
             "samprate": sample_rate,
-            "replace_nulls": int(replace_nulls == True),
+            "replace_nulls": int(replace_nulls),
         }
         if fulcra_userid is not None:
             params["fulcra_userid"] = fulcra_userid
@@ -998,7 +999,7 @@ class FulcraAPI:
             "metric": metric,
             "output": "arrow",
             "samprate": sample_rate,
-            "replace_nulls": int(replace_nulls == True),
+            "replace_nulls": int(replace_nulls),
         }
         if calculations is not None:
             params["calculations"] = calculations

--- a/tests/test_auth_code_flow.py
+++ b/tests/test_auth_code_flow.py
@@ -1,14 +1,10 @@
-import pytest
-from fulcra_api.core import (
-    FulcraAPI,
-    FULCRA_OIDC_DOMAIN,
-    FULCRA_OIDC_CLIENT_ID,
-    FULCRA_OIDC_AUDIENCE,
-    FULCRA_OIDC_SCOPE,
-)
-import urllib.parse
 import datetime
+import urllib.parse
 from unittest.mock import patch
+
+import pytest
+
+from fulcra_api.core import FulcraAPI
 
 
 @pytest.fixture

--- a/tests/test_auth_code_flow.py
+++ b/tests/test_auth_code_flow.py
@@ -1,23 +1,31 @@
 import pytest
-from fulcra_api.core import FulcraAPI, FULCRA_OIDC_DOMAIN, FULCRA_OIDC_CLIENT_ID, FULCRA_OIDC_AUDIENCE, FULCRA_OIDC_SCOPE
+from fulcra_api.core import (
+    FulcraAPI,
+    FULCRA_OIDC_DOMAIN,
+    FULCRA_OIDC_CLIENT_ID,
+    FULCRA_OIDC_AUDIENCE,
+    FULCRA_OIDC_SCOPE,
+)
 import urllib.parse
 import datetime
 from unittest.mock import patch
+
 
 @pytest.fixture
 def client() -> FulcraAPI:
     """Provides a fresh FulcraAPI client for each test."""
     return FulcraAPI()
 
+
 def test_get_authorization_code_url_basic(client: FulcraAPI):
     redirect_uri = "https://testing.fulcradynamics.com/callback"
     url_str = client.get_authorization_code_url(redirect_uri=redirect_uri)
-    
+
     assert url_str.startswith(f"https://{client.oidc_domain}/authorize?")
-    
+
     parsed_url = urllib.parse.urlparse(url_str)
     query_params = urllib.parse.parse_qs(parsed_url.query)
-    
+
     assert query_params["client_id"] == [client.oidc_client_id]
     assert query_params["audience"] == [client.oidc_audience]
     assert query_params["scope"] == [client.oidc_scope]
@@ -25,120 +33,148 @@ def test_get_authorization_code_url_basic(client: FulcraAPI):
     assert query_params["redirect_uri"] == [redirect_uri]
     assert "state" not in query_params
 
+
 def test_get_authorization_code_url_with_state(client: FulcraAPI):
     redirect_uri = "https://testing.fulcradynamics.com/callback"
     state = "randomstate123"
     url_str = client.get_authorization_code_url(redirect_uri=redirect_uri, state=state)
-    
+
     parsed_url = urllib.parse.urlparse(url_str)
     query_params = urllib.parse.parse_qs(parsed_url.query)
-    
+
     assert query_params["state"] == [state]
     assert query_params["redirect_uri"] == [redirect_uri]
 
 
-@patch('fulcra_api.core.FulcraAPI._fetch_token_from_auth_server')
+@patch("fulcra_api.core.FulcraAPI._fetch_token_from_auth_server")
 def test_authorize_with_authorization_code_success(mock_fetch_token, client: FulcraAPI):
     code = "auth_code_123"
     redirect_uri = "https://testing.fulcradynamics.com/callback"
-    
+
     mock_access_token = "mock_access_token_val"
     mock_refresh_token = "mock_refresh_token_val"
     mock_expiration = datetime.datetime.now() + datetime.timedelta(hours=1)
-    
-    mock_fetch_token.return_value = (mock_access_token, mock_expiration, mock_refresh_token)
-    
+
+    mock_fetch_token.return_value = (
+        mock_access_token,
+        mock_expiration,
+        mock_refresh_token,
+    )
+
     client.authorize_with_authorization_code(code=code, redirect_uri=redirect_uri)
-    
-    mock_fetch_token.assert_called_once_with({
-        "grant_type": "authorization_code",
-        "client_id": client.oidc_client_id, # Uses instance client_id
-        "code": code,
-        "redirect_uri": redirect_uri,
-    })
-    
+
+    mock_fetch_token.assert_called_once_with(
+        {
+            "grant_type": "authorization_code",
+            "client_id": client.oidc_client_id,  # Uses instance client_id
+            "code": code,
+            "redirect_uri": redirect_uri,
+        }
+    )
+
     assert client.fulcra_cached_access_token == mock_access_token
     assert client.fulcra_cached_access_token_expiration == mock_expiration
     assert client.fulcra_cached_refresh_token == mock_refresh_token
 
-@patch('fulcra_api.core.FulcraAPI._fetch_token_from_auth_server')
+
+@patch("fulcra_api.core.FulcraAPI._fetch_token_from_auth_server")
 def test_authorize_with_authorization_code_failure(mock_fetch_token, client: FulcraAPI):
     code = "auth_code_123"
     redirect_uri = "https://testing.fulcradynamics.com/callback"
-    
+
     mock_fetch_token.return_value = (None, None, None)
-    
-    with pytest.raises(Exception, match="Failed to exchange authorization code for token."):
+
+    with pytest.raises(
+        Exception, match="Failed to exchange authorization code for token."
+    ):
         client.authorize_with_authorization_code(code=code, redirect_uri=redirect_uri)
-        
+
     assert client.fulcra_cached_access_token is None
     assert client.fulcra_cached_access_token_expiration is None
     assert client.fulcra_cached_refresh_token is None
 
+
 def test_refresh_access_token_no_initial_refresh_token(client: FulcraAPI):
     client.fulcra_cached_refresh_token = None
-    with pytest.raises(Exception, match="No refresh token available to refresh the access token."):
+    with pytest.raises(
+        Exception, match="No refresh token available to refresh the access token."
+    ):
         client.refresh_access_token()
 
-@patch('fulcra_api.core.FulcraAPI._fetch_token_from_auth_server')
-def test_refresh_access_token_success_with_new_refresh_token(mock_fetch_token, client: FulcraAPI):
+
+@patch("fulcra_api.core.FulcraAPI._fetch_token_from_auth_server")
+def test_refresh_access_token_success_with_new_refresh_token(
+    mock_fetch_token, client: FulcraAPI
+):
     initial_refresh_token = "initial_refresh_token"
     client.fulcra_cached_refresh_token = initial_refresh_token
-    
+
     new_access_token = "new_access_token_val"
-    new_refresh_token = "new_refresh_token_val" # Simulating refresh token rotation
+    new_refresh_token = "new_refresh_token_val"  # Simulating refresh token rotation
     new_expiration = datetime.datetime.now() + datetime.timedelta(hours=1)
-    
-    mock_fetch_token.return_value = (new_access_token, new_expiration, new_refresh_token)
-    
+
+    mock_fetch_token.return_value = (
+        new_access_token,
+        new_expiration,
+        new_refresh_token,
+    )
+
     result = client.refresh_access_token()
-    
+
     assert result is True
-    mock_fetch_token.assert_called_once_with({
-        "grant_type": "refresh_token",
-        "client_id": client.oidc_client_id, # Uses instance client_id
-        "refresh_token": initial_refresh_token,
-        "scope": client.oidc_scope,       # Uses instance scope
-    })
-    
+    mock_fetch_token.assert_called_once_with(
+        {
+            "grant_type": "refresh_token",
+            "client_id": client.oidc_client_id,  # Uses instance client_id
+            "refresh_token": initial_refresh_token,
+            "scope": client.oidc_scope,  # Uses instance scope
+        }
+    )
+
     assert client.fulcra_cached_access_token == new_access_token
     assert client.fulcra_cached_access_token_expiration == new_expiration
     assert client.fulcra_cached_refresh_token == new_refresh_token
 
-@patch('fulcra_api.core.FulcraAPI._fetch_token_from_auth_server')
-def test_refresh_access_token_success_no_new_refresh_token(mock_fetch_token, client: FulcraAPI):
+
+@patch("fulcra_api.core.FulcraAPI._fetch_token_from_auth_server")
+def test_refresh_access_token_success_no_new_refresh_token(
+    mock_fetch_token, client: FulcraAPI
+):
     initial_refresh_token = "initial_refresh_token_no_rotate"
     client.fulcra_cached_refresh_token = initial_refresh_token
-    
+
     new_access_token = "new_access_token_val_no_rotate"
     # Server does not return a new refresh token
     new_expiration = datetime.datetime.now() + datetime.timedelta(hours=1)
-    
-    mock_fetch_token.return_value = (new_access_token, new_expiration, None) 
-    
+
+    mock_fetch_token.return_value = (new_access_token, new_expiration, None)
+
     result = client.refresh_access_token()
-    
+
     assert result is True
     assert client.fulcra_cached_access_token == new_access_token
     assert client.fulcra_cached_access_token_expiration == new_expiration
     # Refresh token should remain the old one
     assert client.fulcra_cached_refresh_token == initial_refresh_token
 
-@patch('fulcra_api.core.FulcraAPI._fetch_token_from_auth_server')
+
+@patch("fulcra_api.core.FulcraAPI._fetch_token_from_auth_server")
 def test_refresh_access_token_failure(mock_fetch_token, client: FulcraAPI):
     initial_refresh_token = "initial_refresh_token_fail"
     client.fulcra_cached_refresh_token = initial_refresh_token
-    
+
     # Store original token values to check they are not cleared on simple failure
     original_access_token = "original_access_token"
-    original_expiration = datetime.datetime.now() - datetime.timedelta(hours=1) # Expired
+    original_expiration = datetime.datetime.now() - datetime.timedelta(
+        hours=1
+    )  # Expired
     client.fulcra_cached_access_token = original_access_token
     client.fulcra_cached_access_token_expiration = original_expiration
 
     mock_fetch_token.return_value = (None, None, None)
-    
+
     result = client.refresh_access_token()
-    
+
     assert result is False
     # Current implementation does not clear tokens on refresh failure, it just returns False.
     assert client.fulcra_cached_access_token == original_access_token

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -359,7 +359,15 @@ def test_metric_time_series_with_calculations(fulcra_client):
         end_time="2024-01-25 00:00:00-08:00",
         sample_rate=3600,
         metric="HeartRate",
-        calculations=["min", "max", "mean", "delta", "uniques", "allpoints", "rollingmean"],
+        calculations=[
+            "min",
+            "max",
+            "mean",
+            "delta",
+            "uniques",
+            "allpoints",
+            "rollingmean",
+        ],
     )
     print(df.columns)
     assert "min_heart_rate" in df

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,8 +1,10 @@
-from fulcra_api.core import FulcraAPI
-import pytest
 import uuid
-from typing import List
 from datetime import datetime
+from typing import List
+
+import pytest
+
+from fulcra_api.core import FulcraAPI
 
 
 @pytest.fixture(scope="session")
@@ -138,63 +140,6 @@ def test_workouts(fulcra_client):
         assert False
     except Exception:
         assert True
-
-
-def test_simple_events(fulcra_client):
-    events = fulcra_client.simple_events(
-        start_time="2022-05-01 04:00:00.000Z", end_time="2023-08-03 04:00:00.000Z"
-    )
-    assert isinstance(events, List)
-    events = fulcra_client.simple_events(
-        start_time="2022-05-01 04:00:00.000Z",
-        end_time="2023-08-03 04:00:00.000Z",
-        fulcra_userid=fulcra_client.get_fulcra_userid(),
-    )
-    assert isinstance(events, List)
-    try:
-        events = fulcra_client.simple_events(
-            start_time="2022-05-01 04:00:00.000Z",
-            end_time="2023-08-03 04:00:00.000Z",
-            fulcra_userid="13371337-1337-1337-81e7-a102ab7d3ff8",
-        )
-        assert False
-    except Exception:
-        assert True
-
-    filtered_events = fulcra_client.simple_events(
-        start_time="2022-05-01 04:00:00.000Z",
-        end_time="2023-08-03 04:00:00.000Z",
-        categories=["testxyz", "nothing"],
-    )
-    assert isinstance(filtered_events, List)
-
-    events = fulcra_client.simple_events(
-        start_time=datetime.fromisoformat("2022-05-01 04:00:00.000+00:00"),
-        end_time=datetime.fromisoformat("2023-08-03 04:00:00.000+00:00"),
-    )
-    assert isinstance(events, List)
-    events = fulcra_client.simple_events(
-        start_time=datetime.fromisoformat("2022-05-01 04:00:00.000+00:00"),
-        end_time=datetime.fromisoformat("2023-08-03 04:00:00.000+00:00"),
-        fulcra_userid=fulcra_client.get_fulcra_userid(),
-    )
-    assert isinstance(events, List)
-    try:
-        events = fulcra_client.simple_events(
-            start_time=datetime.fromisoformat("2022-05-01 04:00:00.000+00:00"),
-            end_time=datetime.fromisoformat("2023-08-03 04:00:00.000+00:00"),
-            fulcra_userid="13371337-1337-1337-81e7-a102ab7d3ff8",
-        )
-        assert False
-    except Exception:
-        assert True
-
-    filtered_events = fulcra_client.simple_events(
-        start_time=datetime.fromisoformat("2022-05-01 04:00:00.000+00:00"),
-        end_time=datetime.fromisoformat("2023-08-03 04:00:00.000+00:00"),
-        categories=["testxyz", "nothing"],
-    )
-    assert isinstance(filtered_events, List)
 
 
 def test_metric_samples(fulcra_client):
@@ -530,11 +475,55 @@ def test_location_at_time(fulcra_client):
         assert True
 
 
-def test_custom_inputs(fulcra_client):
-    loc = fulcra_client.custom_input_events("2024-06-01T00:00Z", "2024-06-10T00:00Z")
+def test_moment_annotations(fulcra_client):
+    loc = fulcra_client.moment_annotations("2024-06-01T00:00Z", "2024-06-10T00:00Z")
     assert type(loc) is list
 
-    loc = fulcra_client.custom_input_events(
+    loc = fulcra_client.moment_annotations(
+        datetime.fromisoformat("2024-06-01T00:00+00:00"),
+        datetime.fromisoformat("2024-06-10T00:00+00:00"),
+    )
+    assert type(loc) is list
+
+
+def test_duration_annotations(fulcra_client):
+    loc = fulcra_client.duration_annotations("2024-06-01T00:00Z", "2024-06-10T00:00Z")
+    assert type(loc) is list
+
+    loc = fulcra_client.duration_annotations(
+        datetime.fromisoformat("2024-06-01T00:00+00:00"),
+        datetime.fromisoformat("2024-06-10T00:00+00:00"),
+    )
+    assert type(loc) is list
+
+
+def test_boolean_annotations(fulcra_client):
+    loc = fulcra_client.boolean_annotations("2024-06-01T00:00Z", "2024-06-10T00:00Z")
+    assert type(loc) is list
+
+    loc = fulcra_client.boolean_annotations(
+        datetime.fromisoformat("2024-06-01T00:00+00:00"),
+        datetime.fromisoformat("2024-06-10T00:00+00:00"),
+    )
+    assert type(loc) is list
+
+
+def test_numeric_annotations(fulcra_client):
+    loc = fulcra_client.numeric_annotations("2024-06-01T00:00Z", "2024-06-10T00:00Z")
+    assert type(loc) is list
+
+    loc = fulcra_client.numeric_annotations(
+        datetime.fromisoformat("2024-06-01T00:00+00:00"),
+        datetime.fromisoformat("2024-06-10T00:00+00:00"),
+    )
+    assert type(loc) is list
+
+
+def test_scale_annotations(fulcra_client):
+    loc = fulcra_client.scale_annotations("2024-06-01T00:00Z", "2024-06-10T00:00Z")
+    assert type(loc) is list
+
+    loc = fulcra_client.scale_annotations(
         datetime.fromisoformat("2024-06-01T00:00+00:00"),
         datetime.fromisoformat("2024-06-10T00:00+00:00"),
     )


### PR DESCRIPTION
- Drops deprecated `simple_events` and `custom_input_events` methods which query for endpoints/data that no longer exist in the Life API.
- Adds support for recorded Fulcra Annotations.
- Ruff linting/formatting