### PR TITLE
[core] Expand fulcra_api functionality

### DIFF
--- a/fulcra_api/core.py
+++ b/fulcra_api/core.py
@@ -325,15 +325,18 @@ class FulcraAPI:
         method: str = "GET",
         query: Optional[dict[str, str]] = None,
         data: Optional[dict] = None,
-        return_raw_response: bool = False,
+        return_http_response: bool = False,
     ) -> bytes | http.client.HTTPResponse:
         """
         Make a call to the given url path (e.g. `/v0/data/metric_time_series?...`)
         with the specified access token.
 
         Params:
-            access_token: The access token to authenticate the request with
             url_path: The path of the URL to use (e.g. `"/v0/data/..."`)
+            method: The HTTP method for the request (Default: GET)
+            query: Key/value pairs of query params
+            data: Dictionary that will get serialized into JSON as the request body
+            return_http_response: Return a HTTPResponse object instead of bytes (default: False)
 
         Returns:
             The raw response data (as bytes).  Raises an exception on failure.
@@ -370,7 +373,7 @@ class FulcraAPI:
         req = urllib.request.Request(url=url, data=ds, headers=headers, method=method)
         response = urllib.request.urlopen(req)
 
-        if return_raw_response:
+        if return_http_response:
             return response
 
         return response.read()

--- a/fulcra_api/core.py
+++ b/fulcra_api/core.py
@@ -4,6 +4,7 @@ import http.client
 import io
 import json
 import os
+import os.path
 import urllib.parse
 import urllib.request
 import webbrowser
@@ -319,8 +320,13 @@ class FulcraAPI:
         return True
 
     def fulcra_api(
-        self, url_path: str, query: Optional[dict[str, str]] = None
-    ) -> bytes:
+        self,
+        url_path: str,
+        method: str = "GET",
+        query: Optional[dict[str, str]] = None,
+        data: Optional[dict] = None,
+        return_raw_response: bool = False,
+    ) -> bytes | http.client.HTTPResponse:
         """
         Make a call to the given url path (e.g. `/v0/data/metric_time_series?...`)
         with the specified access token.
@@ -354,8 +360,18 @@ class FulcraAPI:
 
         url = urllib.parse.urlunparse((proto, host, url_path, "", url_query, ""))
         headers = {"Authorization": f"Bearer {self.fulcra_credentials.access_token}"}
-        req = urllib.request.Request(url=url, headers=headers, method="GET")
+
+        if data:
+            headers["Content-Type"] = "application/json"
+            ds = json.dumps(data).encode("UTF-8")
+        else:
+            ds = None
+
+        req = urllib.request.Request(url=url, data=ds, headers=headers, method=method)
         response = urllib.request.urlopen(req)
+
+        if return_raw_response:
+            return response
 
         return response.read()
 

--- a/shell.nix
+++ b/shell.nix
@@ -14,11 +14,14 @@ let
 in
 pkgs.mkShell {
   packages = [ pythonEnv ];
+  env = {
+    UV_PYTHON = pythonEnv.python.interpreter;
+    UV_PYTHON_DOWNLOADS = "never";
+  };
   shellHook = ''
-    export PYTHONHOME=${pythonEnv}
-    export UV_PYTHON_DOWNLOADS=never
-    export UV_PYTHON_PREFERENCE=only-system
-    export UV_PYTHON=${pythonEnv}
     export PATH=.venv/bin/:$PATH
+
+    # LD_LIBRARY_PATH magic for NixOS + nix-ld environments so we can import numpy/etc
+    [ -n "''${NIX_LD_LIBRARY_PATH:-}" ] && export LD_LIBRARY_PATH="$NIX_LD_LIBRARY_PATH" || true
   '';
 }


### PR DESCRIPTION
`fulcra_api()` is the core method that makes requests to the Fulcra Life API. This extends the functionality to allow us to:

- Use HTTP request methods other than `GET`
- Send a JSON object as the request body
- Return a `HTTPResponse` object instead of the response body as bytes