### PR TITLE
[CLI] Implement initial file management commands

### DIFF
--- a/fulcra_api/cli.py
+++ b/fulcra_api/cli.py
@@ -956,15 +956,14 @@ def file_list(ctx, path: str):
             click.echo(f"{d}/")
 
     for f in results.get("files", []):
-        if f.get("state") == "uploaded":
-            size, unit = human_size(f.get("size"))
-            try:
-                dt = datetime.fromisoformat(f.get("uploaded_at"))
-            except TypeError as exc:
-                dt = datetime(1970, 1, 1, tzinfo=timezone.utc)
-            click.echo(
-                f"{str(size) + unit:7} {dt.strftime('%Y-%m-%d %I:%M%p %Z')}  {f.get('name')}"
-            )
+        size, unit = human_size(f.get("size"))
+        try:
+            dt = datetime.fromisoformat(f.get("uploaded_at"))
+        except TypeError as exc:
+            dt = datetime(1970, 1, 1, tzinfo=timezone.utc)
+        click.echo(
+            f"{str(size) + unit:7} {dt.strftime('%Y-%m-%d %I:%M%p %Z')}  {f.get('name')}"
+        )
 
 
 @file.command("stat", short_help="Get information about a library file")
@@ -980,7 +979,7 @@ def file_stat(ctx, path: str):
     path = ctx.obj.make_filepath(path)
 
     try:
-        f = ctx.obj.resolve_filepath(path)
+        f = ctx.obj.resolve_filepath(path, all_versions=True)
     except Exception as exc:
         raise click.ClickException(exc)
 

--- a/fulcra_api/cli.py
+++ b/fulcra_api/cli.py
@@ -939,7 +939,7 @@ def user_info(ctx):
 #
 
 
-@cli.group(help="File library sub-commands")
+@cli.group(help="File management sub-commands")
 def file():
     pass
 
@@ -973,7 +973,7 @@ def file_list(ctx, path: str):
         )
 
 
-@file.command("stat", short_help="Get information about a library file")
+@file.command("stat", short_help="Get information about a file")
 @click.argument("path", type=str)
 @click.pass_context
 @requires_auth
@@ -1002,13 +1002,13 @@ def file_stat(ctx, path: str):
         click.echo(f"- {file['id']} {file['uploaded_at']} ({file['size']} bytes)")
 
 
-@file.command("download", short_help="Download a library file")
+@file.command("download", short_help="Download a file")
 @click.argument("remote_file", type=str)
 @click.argument("local_file", type=click.File(mode="wb"), required=False, default=None)
 @click.pass_context
 @requires_auth
 def file_download(ctx, remote_file: str, local_file=None):
-    """Download a library file.
+    """Download a file.
 
     REMOTE_FILE: Full path of file to download.
 
@@ -1033,13 +1033,13 @@ def file_download(ctx, remote_file: str, local_file=None):
         click.echo(f"⬇️ fulcra:{remote_file} -> {local_file.name}")
 
 
-@file.command("upload", short_help="Upload a library file")
+@file.command("upload", short_help="Upload a file")
 @click.argument("local_file", type=click.File(mode="rb"))
 @click.argument("remote_file", type=str, default="")
 @click.pass_context
 @requires_auth
 def file_upload(ctx, local_file: click.File, remote_file: str):
-    """Upload a library file.
+    """Upload a file.
 
     LOCAL_FILE: File to upload.
 

--- a/fulcra_api/cli.py
+++ b/fulcra_api/cli.py
@@ -63,7 +63,7 @@ def human_size(n: int) -> tuple[int, str]:
 
 def make_filepath(path: str, filename: str = "") -> str:
     """make file path string from given path and filename"""
-    filepath = PurePath("/", path, filename)
+    filepath = pathlib.PurePath("/", path, filename)
 
     return str(filepath)
 

--- a/fulcra_api/cli.py
+++ b/fulcra_api/cli.py
@@ -61,6 +61,13 @@ def human_size(n: int) -> tuple[int, str]:
     return n, "EiB"
 
 
+def make_filepath(path: str, filename: str = "") -> str:
+    """make file path string from given path and filename"""
+    filepath = PurePath("/", path, filename)
+
+    return str(filepath)
+
+
 def parse_time(ctx: click.Context, param: click.Parameter, value: str) -> datetime:
     """
     callback to parse a time string through dateparser and return datetime
@@ -947,7 +954,7 @@ def file_list(ctx, path: str):
     PATH: Path to list files in [Default: /]
     """
 
-    path = ctx.obj.make_filepath(path)
+    path = make_filepath(path)
 
     results = ctx.obj.list_files(path)
 
@@ -976,7 +983,7 @@ def file_stat(ctx, path: str):
     PATH: Full path of the file.
     """
 
-    path = ctx.obj.make_filepath(path)
+    path = make_filepath(path)
 
     try:
         f = ctx.obj.resolve_filepath(path, all_versions=True)
@@ -986,7 +993,7 @@ def file_stat(ctx, path: str):
     latest_version = f[0]
 
     click.echo(
-        f"{ctx.obj.make_filepath(latest_version['path'], latest_version['name'])} ({latest_version['size']} bytes)"
+        f"{make_filepath(latest_version['path'], latest_version['name'])} ({latest_version['size']} bytes)"
     )
     click.echo(f"Uploaded: {latest_version['uploaded_at']}")
     click.echo(f"Version: {latest_version['id']}")
@@ -1008,7 +1015,7 @@ def file_download(ctx, remote_file: str, local_file=None):
     LOCAL_FILE: Path to save downloaded file to, use `-` to print file contents to STDOUT. [Default: REMOTE_FILE name]
     """
 
-    remote_file = ctx.obj.make_filepath(remote_file)
+    remote_file = make_filepath(remote_file)
 
     try:
         f = ctx.obj.resolve_filepath(remote_file)
@@ -1042,9 +1049,9 @@ def file_upload(ctx, local_file: click.File, remote_file: str):
         raise click.ClickException("Cannot upload from stdin")
 
     if remote_file != "":
-        path = ctx.obj.make_filepath(remote_file)
+        path = make_filepath(remote_file)
     else:
-        path = ctx.obj.make_filepath(local_file.name)
+        path = make_filepath(local_file.name)
 
     file_size = os.path.getsize(local_file.name)
     try:
@@ -1054,9 +1061,7 @@ def file_upload(ctx, local_file: click.File, remote_file: str):
 
     try:
         new_file = ctx.obj.upload_file(local_file, file_type, file_size, path)
-        full_path = ctx.obj.make_filepath(
-            new_file["file"]["path"], new_file["file"]["name"]
-        )
+        full_path = make_filepath(new_file["file"]["path"], new_file["file"]["name"])
     except HTTPError as exc:
         raise click.ClickException(exc.fp.read())
 
@@ -1072,7 +1077,7 @@ def file_delete(ctx, path):
 
     PATH: Path of the file to delete.
     """
-    path = ctx.obj.make_filepath(path)
+    path = make_filepath(path)
 
     try:
         f = ctx.obj.resolve_filepath(path)
@@ -1102,7 +1107,7 @@ def file_restore(ctx, version_id):
         else:
             raise click.ClickException(exc)
 
-    full_file_name = ctx.obj.make_filepath(file_version["path"], file_version["name"])
+    full_file_name = make_filepath(file_version["path"], file_version["name"])
 
     new_file = ctx.obj.restore_file(file_version["id"])
 

--- a/fulcra_api/cli.py
+++ b/fulcra_api/cli.py
@@ -10,6 +10,7 @@ from uuid import UUID
 
 import click
 import dateparser
+import puremagic
 
 from .core import FulcraAPI
 from .credentials import FulcraCredentials
@@ -49,6 +50,15 @@ def requires_auth(f):
         return f(ctx, *args, **kwargs)
 
     return wrapper
+
+
+def human_size(n: int) -> tuple[int, str]:
+    units = ["B", "KiB", "MiB", "GiB", "TiB", "PiB"]
+    for unit in units:
+        if n < 1024:
+            return n, unit
+        n //= 1024
+    return n, "EiB"
 
 
 def parse_time(ctx: click.Context, param: click.Parameter, value: str) -> datetime:
@@ -137,8 +147,9 @@ def time_range(func):
 
 
 @click.group()
+@click.option("--beta", is_flag=True, default=False, help="Enable beta features")
 @click.pass_context
-def cli(ctx):
+def cli(ctx, beta):
     """Command line interface for authenticating and interacting with the Fulcra Life API.
 
     Sub-commands return JSON data by default for convienent piping into tools like `jq` for parsing and filtering.
@@ -914,6 +925,191 @@ def user_info(ctx):
         raise click.ClickException(exc) from exc
 
     click.echo(json.dumps(resp))
+
+
+#
+# File functionality
+#
+
+
+@cli.group(help="File library sub-commands")
+def file():
+    pass
+
+
+@file.command("list", short_help="List files")
+@click.argument("path", type=str, default="/")
+@click.pass_context
+@requires_auth
+def file_list(ctx, path: str):
+    """List uploaded files.
+
+    PATH: Path to list files in [Default: /]
+    """
+
+    path = ctx.obj.make_filepath(path)
+
+    results = ctx.obj.list_files(path)
+
+    if results.get("folders") is not None:
+        for d in results.get("folders", []):
+            click.echo(f"{d}/")
+
+    for f in results.get("files", []):
+        if f.get("state") == "uploaded":
+            size, unit = human_size(f.get("size"))
+            try:
+                dt = datetime.fromisoformat(f.get("uploaded_at"))
+            except TypeError as exc:
+                dt = datetime(1970, 1, 1, tzinfo=timezone.utc)
+            click.echo(
+                f"{str(size) + unit:7} {dt.strftime('%Y-%m-%d %I:%M%p %Z')}  {f.get('name')}"
+            )
+
+
+@file.command("stat", short_help="Get information about a library file")
+@click.argument("path", type=str)
+@click.pass_context
+@requires_auth
+def file_stat(ctx, path: str):
+    """Returns information about an uploaded file, including size, date uploaded, and all previously uploaded versions of the file.
+
+    PATH: Full path of the file.
+    """
+
+    path = ctx.obj.make_filepath(path)
+
+    try:
+        f = ctx.obj.resolve_filepath(path)
+    except Exception as exc:
+        raise click.ClickException(exc)
+
+    latest_version = f[0]
+
+    click.echo(
+        f"{latest_version['path']}{latest_version['name']} ({latest_version['size']} bytes)"
+    )
+    click.echo(f"Uploaded: {latest_version['uploaded_at']}")
+    click.echo(f"Version: {latest_version['id']}")
+    click.echo(f"Previous Versions: {len(f[1:])}")
+    for file in f[1:]:
+        click.echo(f"- {file['id']} {file['uploaded_at']} ({file['size']} bytes)")
+
+
+@file.command("download", short_help="Download a library file")
+@click.argument("remote_file", type=str)
+@click.argument("local_file", type=click.File(mode="wb"), required=False, default=None)
+@click.pass_context
+@requires_auth
+def file_download(ctx, remote_file: str, local_file=None):
+    """Download a library file.
+
+    REMOTE_FILE: Full path of file to download.
+
+    LOCAL_FILE: Path to save downloaded file to, use `-` to print file contents to STDOUT. [Default: REMOTE_FILE name]
+    """
+
+    remote_file = ctx.obj.make_filepath(remote_file)
+
+    try:
+        f = ctx.obj.resolve_filepath(remote_file)
+    except Exception as exc:
+        raise click.ClickException(exc)
+
+    resp = ctx.obj.download_file(f[0].get("id"))
+
+    if local_file is None:
+        local_file = click.open_file(pathlib.PurePath(f[0].get("name")).name, mode="wb")
+
+    local_file.write(resp.read())
+
+    if local_file.name != "<stdout>":
+        click.echo(f"⬇️ fulcra:{remote_file} -> {local_file.name}")
+
+
+@file.command("upload", short_help="Upload a library file")
+@click.argument("local_file", type=click.File(mode="rb"))
+@click.argument("remote_file", type=str, default="")
+@click.pass_context
+@requires_auth
+def file_upload(ctx, local_file: click.File, remote_file: str):
+    """Upload a library file.
+
+    LOCAL_FILE: File to upload.
+
+    REMOTE_FILE: Full path to upload file to. [Default: LOCAL_FILE name]
+    """
+    if local_file.name == "<stdin>":
+        raise click.ClickException("Cannot upload from stdin")
+
+    if remote_file != "":
+        path = ctx.obj.make_filepath(remote_file)
+    else:
+        path = ctx.obj.make_filepath(local_file.name)
+
+    file_size = os.path.getsize(local_file.name)
+    try:
+        file_type = puremagic.from_file(local_file.name, mime=True)
+    except puremagic.PureError as exc:
+        file_type = "application/octet-stream"
+
+    try:
+        new_file = ctx.obj.upload_file(local_file, file_type, file_size, path)
+        full_path = ctx.obj.make_filepath(
+            new_file["file"]["path"], new_file["file"]["name"]
+        )
+    except HTTPError as exc:
+        raise click.ClickException(exc.fp.read())
+
+    click.echo(f"⬆️ {local_file.name} -> fulcra:{full_path}")
+
+
+@file.command("delete", short_help="Delete a file")
+@click.argument("path", type=str)
+@click.pass_context
+@requires_auth
+def file_delete(ctx, path):
+    """Delete a file.
+
+    PATH: Path of the file to delete.
+    """
+    path = ctx.obj.make_filepath(path)
+
+    try:
+        f = ctx.obj.resolve_filepath(path)
+    except Exception as exc:
+        raise click.ClickException(exc)
+
+    ctx.obj.delete_file(f[0].get("id"))
+
+    click.echo(f"❌ fulcra:{path}")
+
+
+@file.command("restore", short_help="Restore a file")
+@click.argument("version_id", type=UUID)
+@click.pass_context
+@requires_auth
+def file_restore(ctx, version_id):
+    """Restore a previous version of a file.
+
+    VERSION_ID: UUID of the file version you want to restore. Versions are returned via the `file stat` command.
+    """
+
+    try:
+        file_version = ctx.obj.get_file_by_version(version_id)
+    except HTTPError as exc:
+        if exc.status == 404:
+            raise click.ClickException(f"File version {version_id} not found")
+        else:
+            raise click.ClickException(exc)
+
+    full_file_name = ctx.obj.make_filepath(file_version["path"], file_version["name"])
+
+    new_file = ctx.obj.restore_file(file_version["id"])
+
+    click.echo(
+        f"fulcra:{full_file_name}  {file_version['id']} ({file_version['uploaded_at']}) ➡️ {new_file['id']} ({new_file['uploaded_at']})"
+    )
 
 
 if __name__ == "__main__":

--- a/fulcra_api/cli.py
+++ b/fulcra_api/cli.py
@@ -986,7 +986,7 @@ def file_stat(ctx, path: str):
     latest_version = f[0]
 
     click.echo(
-        f"{latest_version['path']}{latest_version['name']} ({latest_version['size']} bytes)"
+        f"{ctx.obj.make_filepath(latest_version['path'], latest_version['name'])} ({latest_version['size']} bytes)"
     )
     click.echo(f"Uploaded: {latest_version['uploaded_at']}")
     click.echo(f"Version: {latest_version['id']}")

--- a/fulcra_api/core.py
+++ b/fulcra_api/core.py
@@ -1450,12 +1450,6 @@ class FulcraAPI:
     # File functionality
     #
 
-    def make_filepath(self, path: str, filename: str = "") -> str:
-        """make file path string from given path and filename"""
-        filepath = PurePath("/", path, filename)
-
-        return str(filepath)
-
     def list_files(self, path: str = "/", state: str = "uploaded") -> dict:
         resp = self.fulcra_api(
             "/input/v1/file_upload", query={"path": path, "state": state}

--- a/fulcra_api/core.py
+++ b/fulcra_api/core.py
@@ -8,6 +8,7 @@ import os.path
 import urllib.parse
 import urllib.request
 import webbrowser
+from pathlib import PurePath
 from typing import Callable, Dict, List, Optional, Tuple, Union
 
 import pandas as pd
@@ -325,7 +326,7 @@ class FulcraAPI:
         method: str = "GET",
         query: Optional[dict[str, str]] = None,
         data: Optional[dict] = None,
-        return_http_response: bool = False,
+        return_raw_response: bool = False,
     ) -> bytes | http.client.HTTPResponse:
         """
         Make a call to the given url path (e.g. `/v0/data/metric_time_series?...`)
@@ -336,7 +337,7 @@ class FulcraAPI:
             method: The HTTP method for the request (Default: GET)
             query: Key/value pairs of query params
             data: Dictionary that will get serialized into JSON as the request body
-            return_http_response: Return a HTTPResponse object instead of bytes (default: False)
+            return_raw_response: Return a HTTPResponse object instead of bytes (default: False)
 
         Returns:
             The raw response data (as bytes).  Raises an exception on failure.
@@ -373,7 +374,7 @@ class FulcraAPI:
         req = urllib.request.Request(url=url, data=ds, headers=headers, method=method)
         response = urllib.request.urlopen(req)
 
-        if return_http_response:
+        if return_raw_response:
             return response
 
         return response.read()
@@ -1444,3 +1445,99 @@ class FulcraAPI:
 
         resp = self.fulcra_v1_api("metric", "ScaleAnnotation", params)
         return json.loads(resp)
+
+    #
+    # File functionality
+    #
+
+    def make_filepath(self, path: str, filename: str = "") -> str:
+        """make file path string from given path and filename"""
+        filepath = PurePath("/", path, filename)
+
+        return str(filepath)
+
+    def list_files(self, path: str = "/") -> dict:
+        resp = self.fulcra_api("/input/v1/file_upload", query={"path": path})
+        return json.loads(resp)
+
+    def get_file_by_version(self, version_id: str) -> dict:
+        resp = self.fulcra_api(f"/input/v1/file_upload/{version_id}")
+        return json.loads(resp)
+
+    def resolve_filepath(self, filepath: str) -> list[dict]:
+        """Take a fully qualified file path and resolve it to the resource definition"""
+        p = PurePath(filepath)
+
+        path = p.parent
+        name = p.name
+
+        resp = self.fulcra_api(
+            "/input/v1/file_upload",
+            query={
+                "path": str(path),
+                "name": str(name),
+                "include_archived": "true",
+            },
+        )
+
+        rbody = json.loads(resp)
+
+        files = sorted(rbody["files"], key=lambda d: d["uploaded_at"], reverse=True)
+
+        # If there's no files or current versions, it doesn't exist
+        if len(files) == 0 or files[0]["state"] != "uploaded":
+            raise Exception(f"File not found in Fulcra Library: {filepath}")
+
+        return files
+
+    def upload_file(
+        self, data: io.BufferedReader, file_type: str, file_size: int, filepath: str
+    ) -> dict:
+
+        path = PurePath(filepath)
+
+        file_info = {
+            "content_length": file_size,
+            "content_type": file_type,
+            "name": str(path.name),
+            "path": str(path.parent),
+        }
+
+        # make request to create upload
+        resp = self.fulcra_api(
+            "/input/v1/file_upload",
+            data=file_info,
+            method="POST",
+        )
+
+        r = json.loads(resp)
+
+        # get our url back and upload data to it
+        upload_url = r["url"]
+
+        req = urllib.request.Request(
+            upload_url,
+            data=data,
+            headers={"Content-Length": file_size, "Content-Type": file_type},
+            method="POST",
+        )
+        upload_resp = urllib.request.urlopen(req)
+
+        return json.loads(resp)
+
+    def download_file(self, file_id: str) -> http.client.HTTPResponse:
+        """download a file and return the file object"""
+
+        resp = self.fulcra_api(
+            f"/input/v1/file_upload/{file_id}/download", return_raw_response=True
+        )
+
+        return resp
+
+    def delete_file(self, file_id: str):
+        self.fulcra_api(f"/input/v1/file_upload/{file_id}", method="DELETE")
+
+    def restore_file(self, file_id: str):
+        return json.loads(
+            self.fulcra_api(f"/input/v1/file_upload/{file_id}/restore", method="POST")
+        )

--- a/fulcra_api/core.py
+++ b/fulcra_api/core.py
@@ -1456,37 +1456,46 @@ class FulcraAPI:
 
         return str(filepath)
 
-    def list_files(self, path: str = "/") -> dict:
-        resp = self.fulcra_api("/input/v1/file_upload", query={"path": path})
+    def list_files(self, path: str = "/", state: str = "uploaded") -> dict:
+        resp = self.fulcra_api(
+            "/input/v1/file_upload", query={"path": path, "state": state}
+        )
         return json.loads(resp)
 
     def get_file_by_version(self, version_id: str) -> dict:
         resp = self.fulcra_api(f"/input/v1/file_upload/{version_id}")
         return json.loads(resp)
 
-    def resolve_filepath(self, filepath: str) -> list[dict]:
+    def resolve_filepath(self, filepath: str, all_versions: bool = False) -> list[dict]:
         """Take a fully qualified file path and resolve it to the resource definition"""
         p = PurePath(filepath)
 
         path = p.parent
         name = p.name
 
+        if all_versions:
+            state = "uploaded,archived"
+        else:
+            state = "uploaded"
+
         resp = self.fulcra_api(
             "/input/v1/file_upload",
-            query={
-                "path": str(path),
-                "name": str(name),
-                "include_archived": "true",
-            },
+            query={"path": str(path), "name": str(name), "state": state},
         )
 
         rbody = json.loads(resp)
 
-        files = sorted(rbody["files"], key=lambda d: d["uploaded_at"], reverse=True)
+        if all_versions:
+            files = sorted(rbody["files"], key=lambda d: d["uploaded_at"], reverse=True)
 
-        # If there's no files or current versions, it doesn't exist
-        if len(files) == 0 or files[0]["state"] != "uploaded":
-            raise Exception(f"File not found in Fulcra Library: {filepath}")
+            # If there's no files or current versions, it doesn't exist
+            if len(files) == 0 or files[0]["state"] != "uploaded":
+                raise Exception(f"File not found in Fulcra: {filepath}")
+        else:
+            files = rbody["files"]
+
+            if len(files) == 0:
+                raise Exception(f"File not found in Fulcra: {filepath}")
 
         return files
 

--- a/fulcra_api/core.py
+++ b/fulcra_api/core.py
@@ -1532,7 +1532,7 @@ class FulcraAPI:
         )
         upload_resp = urllib.request.urlopen(req)
 
-        return json.loads(resp)
+        return r
 
     def download_file(self, file_id: str) -> http.client.HTTPResponse:
         """download a file and return the file object"""

--- a/fulcra_api/core.py
+++ b/fulcra_api/core.py
@@ -326,7 +326,7 @@ class FulcraAPI:
         method: str = "GET",
         query: Optional[dict[str, str]] = None,
         data: Optional[dict] = None,
-        return_raw_response: bool = False,
+        return_http_response: bool = False,
     ) -> bytes | http.client.HTTPResponse:
         """
         Make a call to the given url path (e.g. `/v0/data/metric_time_series?...`)
@@ -337,7 +337,7 @@ class FulcraAPI:
             method: The HTTP method for the request (Default: GET)
             query: Key/value pairs of query params
             data: Dictionary that will get serialized into JSON as the request body
-            return_raw_response: Return a HTTPResponse object instead of bytes (default: False)
+            return_http_response: Return a HTTPResponse object instead of bytes (default: False)
 
         Returns:
             The raw response data (as bytes).  Raises an exception on failure.
@@ -374,7 +374,7 @@ class FulcraAPI:
         req = urllib.request.Request(url=url, data=ds, headers=headers, method=method)
         response = urllib.request.urlopen(req)
 
-        if return_raw_response:
+        if return_http_response:
             return response
 
         return response.read()

--- a/fulcra_api/core.py
+++ b/fulcra_api/core.py
@@ -1529,7 +1529,7 @@ class FulcraAPI:
         """download a file and return the file object"""
 
         resp = self.fulcra_api(
-            f"/input/v1/file_upload/{file_id}/download", return_raw_response=True
+            f"/input/v1/file_upload/{file_id}/download", return_http_response=True
         )
 
         return resp

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "pytest>=7.4.2,<8",
     "click>=8.2.1",
     "dateparser>=1.4.0",
+    "puremagic>=1.30",
 ]
 packages = [{ include = "fulcra_api" }]
 

--- a/uv.lock
+++ b/uv.lock
@@ -172,6 +172,8 @@ dependencies = [
     { name = "dateparser" },
     { name = "numpy" },
     { name = "pandas" },
+    { name = "puremagic", version = "1.30", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "puremagic", version = "2.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "pyarrow" },
     { name = "pytest" },
 ]
@@ -196,6 +198,7 @@ requires-dist = [
     { name = "dateparser", specifier = ">=1.4.0" },
     { name = "numpy", specifier = ">=2.0.0,<3" },
     { name = "pandas", specifier = ">1.5,<3" },
+    { name = "puremagic", specifier = ">=1.30" },
     { name = "pyarrow", specifier = ">=19.0.0" },
     { name = "pytest", specifier = ">=7.4.2,<8" },
 ]
@@ -609,6 +612,30 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "puremagic"
+version = "1.30"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.12'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dd/7f/9998706bc516bdd664ccf929a1da6c6e5ee06e48f723ce45aae7cf3ff36e/puremagic-1.30.tar.gz", hash = "sha256:f9ff7ac157d54e9cf3bff1addfd97233548e75e685282d84ae11e7ffee1614c9", size = 314785, upload-time = "2025-07-04T18:48:36.061Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/91/ed/1e347d85d05b37a8b9a039ca832e5747e1e5248d0bd66042783ef48b4a37/puremagic-1.30-py3-none-any.whl", hash = "sha256:5eeeb2dd86f335b9cfe8e205346612197af3500c6872dffebf26929f56e9d3c1", size = 43304, upload-time = "2025-07-04T18:48:34.801Z" },
+]
+
+[[package]]
+name = "puremagic"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/24/74/ce5987ab9b8aec4ced06e2723ebb604205c9eb58abdad91453da93166380/puremagic-2.2.0.tar.gz", hash = "sha256:eb4bddf07c177c4b434554b92165b67449f5a51e152b976202d6254498810eef", size = 1189752, upload-time = "2026-04-08T01:39:55.562Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/95/81/314320aeffd88dadeac553ff9eb10f54507ab41deccd0c69f6221d254a0a/puremagic-2.2.0-py3-none-any.whl", hash = "sha256:c4f7ed7307f056c787199acfda839555921be1df13abba61e8e6db0c787ae1d0", size = 71971, upload-time = "2026-04-08T01:39:54.169Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Implements `file` subcommands for basic Fulcra file management:

- `file list <path>` lists files uploaded to fulcra by path
- `file stat <path>` returns information about an uploaded file, including versions
- `file upload <local> <remote>` uploads a file
- `file download <remote> <local>` downloads a file
- `file delete <path>` deletes a file from fulcra
- `file restore <id>` restores a previous version of a file by its version ID