### PR TITLE
Fix file stat path/filename separator (#36)

### DIFF
--- a/fulcra_api/cli.py
+++ b/fulcra_api/cli.py
@@ -986,7 +986,7 @@ def file_stat(ctx, path: str):
     latest_version = f[0]
 
     click.echo(
-        f"{latest_version['path']}{latest_version['name']} ({latest_version['size']} bytes)"
+        f"{ctx.obj.make_filepath(latest_version['path'], latest_version['name'])} ({latest_version['size']} bytes)"
     )
     click.echo(f"Uploaded: {latest_version['uploaded_at']}")
     click.echo(f"Version: {latest_version['id']}")


### PR DESCRIPTION
## What

`fulcra file stat <path>` rendered the file's directory path and name concatenated with no separator, so a file at `/coordination-smoke/smoke-test.json` printed as:

```
/coordination-smokesmoke-test.json (47 bytes)
```

## Why

The path is misleading on its own, and it also leaks downstream: any tooling that parses `file stat` stdout inherits the malformed value — e.g. `fulcra-coord` surfaces it as `path_display` = `/coordination-smokesmoke-test.json`. Reported in #36.

## Fix

Use the existing `make_filepath(path, name)` helper to join the two fields — the same approach the `rollback` command already uses (`cli.py:1105`). `make_filepath` builds the path with `PurePath`, so the separator is always correct whether or not the stored path has a trailing slash. One-line, display-only change; upload/download/stat already operate on the correct path and `file list` was unaffected.

## How tested

Ran the patched CLI against a real file in Fulcra Files:

```
$ fulcra file stat /coordination-smoke/smoke-test.json
/coordination-smoke/smoke-test.json (47 bytes)   # was: /coordination-smokesmoke-test.json
Uploaded: 2026-06-01T20:38:57.532047Z
Version: 4d730b43-dd58-45d1-837f-f9fa68b3aa7d
Previous Versions: 0
```

Base branch is `file-management` because the `file` command group does not exist on `main`.

Fixes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)