### PR TITLE
Add default None values for FulcraAPI.v1_catalog()

### DIFF
--- a/fulcra_api/core.py
+++ b/fulcra_api/core.py
@@ -978,7 +978,7 @@ class FulcraAPI:
         return json.loads(resp)
 
     def v1_catalog(
-        self, data_type: Optional[str], category: Optional[str]
+        self, data_type: Optional[str] = None, category: Optional[str] = None
     ) -> List[Dict]:
         params = {}
         if data_type:


### PR DESCRIPTION
- Adds default `None` values for args on `FulcraAPI.v1_catalog(data_type, category)` method