### PR TITLE
Add two-step login flow and --interactive flag

### DIFF
--- a/fulcra_api/cli/auth.py
+++ b/fulcra_api/cli/auth.py
@@ -1,4 +1,5 @@
 import webbrowser
+import json
 
 import click
 
@@ -33,6 +34,51 @@ def login(ctx):
 
     try:
         creds = ctx.obj.oidc.authorize_via_device_flow(prompt_callback=prompt)
+    except Exception as exc:
+        print(exc)
+        raise click.ClickException("Authorization failed, try again.") from exc
+
+    click.echo("✅ Authorization successful!")
+
+    save_creds(creds)
+
+
+@auth.command("start-login", short_help="Authenticate to Fulcra")
+@click.pass_context
+def start_login(ctx):
+    """Gets a URL, code, and device code to authenticate to the Fulcra platform.
+
+    Starts the OAuth Device Authorization Flow isused to authenticate a user to the Fulcra Life API. Returns a JSON object containing a URL the user can open in their browser, a code they should verify when authenticating, and device code that can be used with `fulcra auth finish-login` to complete the CLI authentication once the user has finished the browser flow.
+    """
+
+    try:
+        device_code, uri, code = ctx.obj.oidc.get_device_code()
+    except Exception as exc:
+        print(exc)
+        raise click.ClickException("Authorization failed, try again.") from exc
+
+    click.echo(json.dumps({
+        "url": uri,
+        "code": code,
+        "device_code": device_code,
+    }))
+
+@auth.command("finish-login", short_help="Authenticate to Fulcra")
+@click.argument("device-code", type=str)
+@click.pass_context
+def finish_login(ctx, device_code: str):
+    """Completes authentication to the Fulcra platform.
+
+    Completes the OAuth Device Authorization Flow isused to authenticate a user to the Fulcra Life API, started by the `fulcra auth start-login` command. The user must complete the browser authentication flow before running this command.
+
+    Credentials are persisted on the filesystem at ~/.config/fulcra/credentials.json
+    """
+
+    try:
+        creds = ctx.obj.oidc.get_token(
+            "urn:ietf:params:oauth:grant-type:device_code",
+            {"device_code": device_code},
+        )
     except Exception as exc:
         print(exc)
         raise click.ClickException("Authorization failed, try again.") from exc

--- a/fulcra_api/cli/auth.py
+++ b/fulcra_api/cli/auth.py
@@ -1,5 +1,5 @@
 import webbrowser
-import json
+import sys
 
 import click
 
@@ -12,80 +12,67 @@ def auth():
 
 
 @auth.command(short_help="Authenticate to Fulcra")
+@click.option("-i", "--interactive", default=False, is_flag=True, help="Run interactively. A URL will be presented to load in browser. A new browser session will be automatically launched on supported platforms, and this command will poll for a valid token from the completion of the flow for up to two minutes.")
+@click.option("-d", "--device-code", type=str, default=None, help="Finish authentication with a device code after the browser auth flow is completed")
 @click.pass_context
-def login(ctx):
+def login(ctx, interactive: bool, device_code: str | None):
     """Authenticates to the Fulcra Platform.
 
-    The OAuth Device Authorization Flow isused to authenticate a user to the Fulcra Life API. A URL will be presented to load in browser. A new browser session will be automatically launched on supported platforms.
-
-    Once run this command will poll for a valid token from the completion of the flow for up to two minutes.
+    The OAuth Device Authorization Flow isused to authenticate a user to the Fulcra Life API. A web auth URL, web auth verification code, and a device code will be returned. Call `fulcra-api auth login --device-code <DEVICE CODE>` to complete authentication after finishing the web auth flow.
 
     Credentials are persisted on the filesystem at ~/.config/fulcra/credentials.json
     """
 
-    def prompt(device_code: str, uri: str, code: str):
-        webbrowser.open_new_tab(uri)
-        click.echo(
-            f"✨ Use your browser to log into Fulcra. If your browser does not automatically open, visit this URL: {uri}"
-        )
-        click.echo(
-            f"❗ Ensure the following code matches what's displayed in your browser: {code}"
-        )
+    if interactive and device_code is not None:
+        raise click.ClickException("--interactive and --device-code are mutually exclusive")
 
-    try:
-        creds = ctx.obj.oidc.authorize_via_device_flow(prompt_callback=prompt)
-    except Exception as exc:
-        print(exc)
-        raise click.ClickException("Authorization failed, try again.") from exc
+    if interactive:
+        def prompt(device_code: str, uri: str, code: str):
+            webbrowser.open_new_tab(uri)
+            click.echo(
+                f"✨ Use your browser to log into Fulcra. If your browser does not automatically open, visit this URL: {uri}"
+            )
+            click.echo(
+                f"❗ Ensure the following code matches what's displayed in your browser: {code}"
+            )
 
-    click.echo("✅ Authorization successful!")
+        try:
+            creds = ctx.obj.oidc.authorize_via_device_flow(prompt_callback=prompt)
+        except Exception as exc:
+            print(exc)
+            raise click.ClickException("Authorization failed, try again.") from exc
 
-    save_creds(creds)
+        click.echo("✅ Authorization successful!")
 
+        save_creds(creds)
+        return
+    
+    if device_code is not None:
+        try:
+            creds = ctx.obj.oidc.get_token(
+                "urn:ietf:params:oauth:grant-type:device_code",
+                {"device_code": device_code},
+            )
+        except Exception as exc:
+            print(exc)
+            raise click.ClickException("Authorization failed, try again.") from exc
 
-@auth.command("start-login", short_help="Authenticate to Fulcra")
-@click.pass_context
-def start_login(ctx):
-    """Gets a URL, code, and device code to authenticate to the Fulcra platform.
+        click.echo("✅ Authorization successful!")
 
-    Starts the OAuth Device Authorization Flow isused to authenticate a user to the Fulcra Life API. Returns a JSON object containing a URL the user can open in their browser, a code they should verify when authenticating, and device code that can be used with `fulcra auth finish-login` to complete the CLI authentication once the user has finished the browser flow.
-    """
-
+        save_creds(creds)
+        return
+    
     try:
         device_code, uri, code = ctx.obj.oidc.get_device_code()
     except Exception as exc:
         print(exc)
         raise click.ClickException("Authorization failed, try again.") from exc
 
-    click.echo(json.dumps({
-        "url": uri,
-        "code": code,
-        "device_code": device_code,
-    }))
-
-@auth.command("finish-login", short_help="Authenticate to Fulcra")
-@click.argument("device-code", type=str)
-@click.pass_context
-def finish_login(ctx, device_code: str):
-    """Completes authentication to the Fulcra platform.
-
-    Completes the OAuth Device Authorization Flow isused to authenticate a user to the Fulcra Life API, started by the `fulcra auth start-login` command. The user must complete the browser authentication flow before running this command.
-
-    Credentials are persisted on the filesystem at ~/.config/fulcra/credentials.json
-    """
-
-    try:
-        creds = ctx.obj.oidc.get_token(
-            "urn:ietf:params:oauth:grant-type:device_code",
-            {"device_code": device_code},
-        )
-    except Exception as exc:
-        print(exc)
-        raise click.ClickException("Authorization failed, try again.") from exc
-
-    click.echo("✅ Authorization successful!")
-
-    save_creds(creds)
+    click.echo(f"Web auth URL: {uri}")
+    click.echo(f"Web auth code: {code}")
+    click.echo(f"Device code: {device_code}\n")
+    click.echo("Open the web auth URL in a browser, verify the web auth code, and complete the web auth flow. After finishing the web auth flow, complete authentication with the device code by running:\n")
+    click.echo(f"fulcra-api auth login --device-code {device_code}")
 
 
 @auth.command("print-access-token", short_help="Print Fulcra oauth2 access token")

--- a/fulcra_api/cli/auth.py
+++ b/fulcra_api/cli/auth.py
@@ -68,10 +68,11 @@ def login(ctx, interactive: bool, device_code: str | None):
         print(exc)
         raise click.ClickException("Authorization failed, try again.") from exc
 
+    click.echo("Open the web auth URL in a browser, verify the web auth code, and complete the web auth flow.\n")
     click.echo(f"Web auth URL: {uri}")
-    click.echo(f"Web auth code: {code}")
-    click.echo(f"Device code: {device_code}\n")
-    click.echo("Open the web auth URL in a browser, verify the web auth code, and complete the web auth flow. After finishing the web auth flow, complete authentication with the device code by running:\n")
+    click.echo(f"- Web auth code: {code}")
+    click.echo(f"- Device code: {device_code}\n")
+    click.echo("After finishing the web auth flow, complete authentication with the device code by running:\n")
     click.echo(f"fulcra-api auth login --device-code {device_code}")
 
 

--- a/fulcra_api/cli/auth.py
+++ b/fulcra_api/cli/auth.py
@@ -12,39 +12,33 @@ def auth():
 
 
 @auth.command(short_help="Authenticate to Fulcra")
-@click.option("-i", "--interactive", default=False, is_flag=True, help="Run interactively. A URL will be presented to load in browser. A new browser session will be automatically launched on supported platforms, and this command will poll for a valid token from the completion of the flow for up to two minutes.")
+@click.option("-u", "--get-auth-url", default=False, is_flag=True, help="Run non-interactively. A web auth URL, web auth verification code, and a device code will be returned. Call `fulcra-api auth login --device-code <DEVICE CODE>` to complete authentication after finishing the web auth flow.")
 @click.option("-d", "--device-code", type=str, default=None, help="Finish authentication with a device code after the browser auth flow is completed")
 @click.pass_context
-def login(ctx, interactive: bool, device_code: str | None):
+def login(ctx, get_auth_url: bool, device_code: str | None):
     """Authenticates to the Fulcra Platform.
 
-    The OAuth Device Authorization Flow isused to authenticate a user to the Fulcra Life API. A web auth URL, web auth verification code, and a device code will be returned. Call `fulcra-api auth login --device-code <DEVICE CODE>` to complete authentication after finishing the web auth flow.
+    The OAuth Device Authorization Flow isused to authenticate a user to the Fulcra Life API. Run interactively. A URL will be presented to load in browser. A new browser session will be automatically launched on supported platforms, and this command will poll for a valid token from the completion of the flow for up to two minutes.
 
     Credentials are persisted on the filesystem at ~/.config/fulcra/credentials.json
     """
 
-    if interactive and device_code is not None:
-        raise click.ClickException("--interactive and --device-code are mutually exclusive")
+    if get_auth_url and device_code is not None:
+        raise click.ClickException("--get-auth-url and --device-code are mutually exclusive")
 
-    if interactive:
-        def prompt(device_code: str, uri: str, code: str):
-            webbrowser.open_new_tab(uri)
-            click.echo(
-                f"✨ Use your browser to log into Fulcra. If your browser does not automatically open, visit this URL: {uri}"
-            )
-            click.echo(
-                f"❗ Ensure the following code matches what's displayed in your browser: {code}"
-            )
-
+    if get_auth_url:
         try:
-            creds = ctx.obj.oidc.authorize_via_device_flow(prompt_callback=prompt)
+            device_code, uri, code = ctx.obj.oidc.get_device_code()
         except Exception as exc:
             print(exc)
             raise click.ClickException("Authorization failed, try again.") from exc
 
-        click.echo("✅ Authorization successful!")
-
-        save_creds(creds)
+        click.echo("Open the web auth URL in a browser, verify the web auth code, and complete the web auth flow.\n")
+        click.echo(f"Web auth URL: {uri}")
+        click.echo(f"- Web auth code: {code}")
+        click.echo(f"- Device code: {device_code}\n")
+        click.echo("After finishing the web auth flow, complete authentication with the device code by running:\n")
+        click.echo(f"fulcra-api auth login --device-code {device_code}")
         return
     
     if device_code is not None:
@@ -62,19 +56,25 @@ def login(ctx, interactive: bool, device_code: str | None):
         save_creds(creds)
         return
     
+    def prompt(device_code: str, uri: str, code: str):
+        webbrowser.open_new_tab(uri)
+        click.echo(
+            f"✨ Use your browser to log into Fulcra. If your browser does not automatically open, visit this URL: {uri}"
+        )
+        click.echo(
+            f"❗ Ensure the following code matches what's displayed in your browser: {code}"
+        )
+
     try:
-        device_code, uri, code = ctx.obj.oidc.get_device_code()
+        creds = ctx.obj.oidc.authorize_via_device_flow(prompt_callback=prompt)
     except Exception as exc:
         print(exc)
         raise click.ClickException("Authorization failed, try again.") from exc
 
-    click.echo("Open the web auth URL in a browser, verify the web auth code, and complete the web auth flow.\n")
-    click.echo(f"Web auth URL: {uri}")
-    click.echo(f"- Web auth code: {code}")
-    click.echo(f"- Device code: {device_code}\n")
-    click.echo("After finishing the web auth flow, complete authentication with the device code by running:\n")
-    click.echo(f"fulcra-api auth login --device-code {device_code}")
+    click.echo("✅ Authorization successful!")
 
+    save_creds(creds)
+    
 
 @auth.command("print-access-token", short_help="Print Fulcra oauth2 access token")
 @click.pass_context


### PR DESCRIPTION
Makes the `fulcra-api auth login` command run in two stages by default. The first stage prints instructions including the web auth URL, code, and device code, and the second step accepts a `--device-code` option to fetch the token after the web auth flow is completed. Passing the `--interactive` flag will trigger the existing polling flow.

- resolves #45 

Sample Hermes/Codex run:
```
**Nice. Can you help me log in to fulcra using that tool?

────────────────────────────────────────
  ┊ 💻 $         export PATH="$HOME/.local/bin:$PATH"; uv tool run 'git+https://git@github.com/fulcradynamics/fulcra-api-python.git@noninteractive_login' auth --help  1.7s
  ┊ 💻 $         export PATH="$HOME/.local/bin:$PATH"; uv tool run 'git+https://git@github.com/fulcradynamics/fulcra-api-python.git@noninteractive_login' auth login --help  1.5s
  ┊ 💻 $         export PATH="$HOME/.local/bin:$PATH"; uv tool run 'git+https://git@github.com/fulcradynamics/fulcra-api-python.git@noninteractive_login' auth login  1.9s

╭─ ⚕ Hermes ───────────────────────────────────────────────────────────────────╮
    Yes. I started the Fulcra device-login flow.
    
    Open this URL in your browser:
    
    https://fulcra.us.auth0.com/activate?user_code=JSGC-DVXD
    
    Verify this code if prompted:
    
    JSGC-DVXD
    
    After you complete the browser auth flow, tell me “done” and I’ll finish the login by running:
    
    fulcra-api auth login --device-code 3VOvae4Fli2tU5UfdZ8kmmtX
╰──────────────────────────────────────────────────────────────────────────────╯

────────────────────────────────────────
● Done.

────────────────────────────────────────
  ┊ 💻 $         export PATH="$HOME/.local/bin:$PATH"; uv tool run 'git+https://git@github.com/fulcradynamics/fulcra-api-python.git@noninteractive_login' auth login --device-code 3VOvae4Fli2tU5UfdZ8kmmtX && uv tool run 'git+https://git@github.com/fulcradynamics/fulcra-api-python.git@noninteractive_login' user-info  3.3s

╭─ ⚕ Hermes ───────────────────────────────────────────────────────────────────╮
    You’re logged in successfully.
    
    The tool reported:
    
    ✅ Authorization successful!
    
    I also verified authentication by running user-info. Your Fulcra account is active, with timezone:
    
    America/Los_Angeles
    
    Credentials were persisted at:
    
    ~/.config/fulcra/credentials.json
╰──────────────────────────────────────────────────────────────────────────────╯
 ⚕ gpt-5.5 │ 18.6K/272K │ [█░░░░░░░░░] 7% │ 7m │ ⏲ 9s │ ✓ 1m 
────────────────────────────────────────────────────────────────────────────────
❯ 
────────────────────────────────────────────────────────────────────────────────**
```