### PR TITLE
Auth login polling options

### DIFF
--- a/fulcra_api/cli/auth.py
+++ b/fulcra_api/cli/auth.py
@@ -2,6 +2,7 @@ import webbrowser
 import sys
 
 import click
+import datetime
 
 from .utils import requires_auth, save_creds
 
@@ -14,8 +15,10 @@ def auth():
 @auth.command(short_help="Authenticate to Fulcra")
 @click.option("-u", "--get-auth-url", default=False, is_flag=True, help="Run non-interactively. A web auth URL, web auth verification code, and a device code will be returned. Call `fulcra-api auth login --device-code <DEVICE CODE>` to complete authentication after finishing the web auth flow.")
 @click.option("-d", "--device-code", type=str, default=None, help="Finish authentication with a device code after the browser auth flow is completed")
+@click.option("-p", "--poll-timeout", type=click.FloatRange(min=0), default=120.0, help="Number of seconds to poll while waiting for the web auth flow to be completed. Ignored if --get-auth-url is passed.")
+@click.option("-i", "--poll-interval", type=click.FloatRange(min=0.5), default=0.5, help="Number of seconds between polling attempts. Ignored if --get-auth-url is passed.")
 @click.pass_context
-def login(ctx, get_auth_url: bool, device_code: str | None):
+def login(ctx, get_auth_url: bool, device_code: str | None, poll_timeout: float, poll_interval: float):
     """Authenticates to the Fulcra Platform.
 
     The OAuth Device Authorization Flow isused to authenticate a user to the Fulcra Life API. Run interactively. A URL will be presented to load in browser. A new browser session will be automatically launched on supported platforms, and this command will poll for a valid token from the completion of the flow for up to two minutes.
@@ -43,12 +46,13 @@ def login(ctx, get_auth_url: bool, device_code: str | None):
     
     if device_code is not None:
         try:
-            creds = ctx.obj.oidc.get_token(
-                "urn:ietf:params:oauth:grant-type:device_code",
-                {"device_code": device_code},
+            creds = ctx.obj.oidc.poll_for_token(
+                device_code=device_code,
+                poll_timeout=datetime.timedelta(seconds=poll_timeout),
+                poll_interval=datetime.timedelta(seconds=poll_interval)
             )
+            
         except Exception as exc:
-            print(exc)
             raise click.ClickException("Authorization failed, try again.") from exc
 
         click.echo("✅ Authorization successful!")
@@ -66,7 +70,11 @@ def login(ctx, get_auth_url: bool, device_code: str | None):
         )
 
     try:
-        creds = ctx.obj.oidc.authorize_via_device_flow(prompt_callback=prompt)
+        creds = ctx.obj.oidc.authorize_via_device_flow(
+            prompt_callback=prompt,
+            poll_timeout=datetime.timedelta(seconds=poll_timeout),
+            poll_interval=datetime.timedelta(seconds=poll_interval),
+        )
     except Exception as exc:
         print(exc)
         raise click.ClickException("Authorization failed, try again.") from exc

--- a/fulcra_api/cli/auth.py
+++ b/fulcra_api/cli/auth.py
@@ -53,7 +53,7 @@ def login(ctx, get_auth_url: bool, device_code: str | None, poll_timeout: float,
             )
             
         except Exception as exc:
-            raise click.ClickException("Authorization failed, try again.") from exc
+            raise click.ClickException(f"Authorization failed, try again: {exc}") from exc
 
         click.echo("✅ Authorization successful!")
 
@@ -76,8 +76,7 @@ def login(ctx, get_auth_url: bool, device_code: str | None, poll_timeout: float,
             poll_interval=datetime.timedelta(seconds=poll_interval),
         )
     except Exception as exc:
-        print(exc)
-        raise click.ClickException("Authorization failed, try again.") from exc
+        raise click.ClickException(f"Authorization failed, try again: {exc}") from exc
 
     click.echo("✅ Authorization successful!")
 

--- a/fulcra_api/oidc.py
+++ b/fulcra_api/oidc.py
@@ -59,7 +59,7 @@ class FulcraOIDCProvider:
             except Exception:
                 if datetime.datetime.now() > end_at:
                     break
-                time.sleep(poll_interval.seconds)
+                time.sleep(poll_interval.total_seconds())
                 continue
 
         if creds is None:

--- a/fulcra_api/oidc.py
+++ b/fulcra_api/oidc.py
@@ -34,10 +34,22 @@ class FulcraOIDCProvider:
         if prompt_callback is not None:
             prompt_callback(device_code, uri, code)
 
+        return self.poll_for_token(
+            device_code=device_code,
+            poll_timeout=poll_timeout,
+            poll_interval=poll_interval,
+        )
+
+    
+    def poll_for_token(
+        self,
+        device_code: str,
+        poll_timeout: datetime.timedelta = datetime.timedelta(seconds=120),
+        poll_interval: datetime.timedelta = datetime.timedelta(seconds=0.5),
+    ) -> FulcraCredentials:
         end_at = datetime.datetime.now() + poll_timeout
         creds = None
-        while datetime.datetime.now() < end_at:
-            time.sleep(poll_interval.seconds)
+        while True:
             try:
                 creds = self.get_token(
                     "urn:ietf:params:oauth:grant-type:device_code",
@@ -45,12 +57,16 @@ class FulcraOIDCProvider:
                 )
                 break
             except Exception:
+                if datetime.datetime.now() > end_at:
+                    break
+                time.sleep(poll_interval.seconds)
                 continue
 
         if creds is None:
             raise Exception("Authorization failed")
 
         return creds
+
 
     def authorize_via_authorization_code_flow(
         self,

--- a/fulcra_api/oidc.py
+++ b/fulcra_api/oidc.py
@@ -56,14 +56,11 @@ class FulcraOIDCProvider:
                     {"device_code": device_code},
                 )
                 break
-            except Exception:
+            except Exception as e:
                 if datetime.datetime.now() > end_at:
-                    break
+                    raise e
                 time.sleep(poll_interval.total_seconds())
                 continue
-
-        if creds is None:
-            raise Exception("Authorization failed")
 
         return creds
 


### PR DESCRIPTION
Adds `--poll-timeout` and `--poll-interval` options. The default values preserve the current `auth login` UX. These options are ignored when --get-auth-url is passed, but applied when `--device-code` is passed to allow polling in the two-step login flow.

I changed the polling behavior slightly to poll once before sleeping or checking the timeout so that the two-step flow could be run without polling by setting `--poll-timeout=0`.