### PR TITLE
FulcraAPI typing in CLI

### DIFF
--- a/fulcra_api/cli/__init__.py
+++ b/fulcra_api/cli/__init__.py
@@ -4,10 +4,6 @@ import click
 
 from ..core import FulcraAPI
 from ..credentials import FulcraCredentials
-
-# Create a pass decorator for FulcraAPI to enable type hints in subcommands
-pass_fulcra_api = click.make_pass_decorator(FulcraAPI)
-
 from .auth import auth
 from .commands import (
     catalog,
@@ -30,7 +26,7 @@ from .commands import (
 from .data_types import data_type
 from .files import file
 from .tags import tag
-from .utils import ensure_config_directory, load_creds, save_creds
+from .utils import ensure_config_directory, load_creds, save_creds, pass_fulcra_api
 
 
 @click.group()

--- a/fulcra_api/cli/__init__.py
+++ b/fulcra_api/cli/__init__.py
@@ -28,6 +28,9 @@ from .files import file
 from .tags import tag
 from .utils import ensure_config_directory, load_creds, save_creds
 
+# Create a pass decorator for FulcraAPI to enable type hints in subcommands
+pass_fulcra_api = click.make_pass_decorator(FulcraAPI)
+
 
 @click.group()
 @click.option("--beta", is_flag=True, default=False, help="Enable beta features")

--- a/fulcra_api/cli/__init__.py
+++ b/fulcra_api/cli/__init__.py
@@ -4,6 +4,10 @@ import click
 
 from ..core import FulcraAPI
 from ..credentials import FulcraCredentials
+
+# Create a pass decorator for FulcraAPI to enable type hints in subcommands
+pass_fulcra_api = click.make_pass_decorator(FulcraAPI)
+
 from .auth import auth
 from .commands import (
     catalog,
@@ -27,9 +31,6 @@ from .data_types import data_type
 from .files import file
 from .tags import tag
 from .utils import ensure_config_directory, load_creds, save_creds
-
-# Create a pass decorator for FulcraAPI to enable type hints in subcommands
-pass_fulcra_api = click.make_pass_decorator(FulcraAPI)
 
 
 @click.group()

--- a/fulcra_api/cli/auth.py
+++ b/fulcra_api/cli/auth.py
@@ -4,7 +4,8 @@ import webbrowser
 
 import click
 
-from ..core import FulcraAPI
+from fulcra_api.core import FulcraAPI
+
 from .utils import pass_fulcra_api, requires_auth, save_creds
 
 
@@ -14,12 +15,42 @@ def auth():
 
 
 @auth.command(short_help="Authenticate to Fulcra")
-@click.option("-u", "--get-auth-url", default=False, is_flag=True, help="Run non-interactively. A web auth URL, web auth verification code, and a device code will be returned. Call `fulcra-api auth login --device-code <DEVICE CODE>` to complete authentication after finishing the web auth flow.")
-@click.option("-d", "--device-code", type=str, default=None, help="Finish authentication with a device code after the browser auth flow is completed")
-@click.option("-p", "--poll-timeout", type=click.FloatRange(min=0), default=120.0, help="Number of seconds to poll while waiting for the web auth flow to be completed. Ignored if --get-auth-url is passed.")
-@click.option("-i", "--poll-interval", type=click.FloatRange(min=0.5), default=0.5, help="Number of seconds between polling attempts. Ignored if --get-auth-url is passed.")
+@click.option(
+    "-u",
+    "--get-auth-url",
+    default=False,
+    is_flag=True,
+    help="Run non-interactively. A web auth URL, web auth verification code, and a device code will be returned. Call `fulcra-api auth login --device-code <DEVICE CODE>` to complete authentication after finishing the web auth flow.",
+)
+@click.option(
+    "-d",
+    "--device-code",
+    type=str,
+    default=None,
+    help="Finish authentication with a device code after the browser auth flow is completed",
+)
+@click.option(
+    "-p",
+    "--poll-timeout",
+    type=click.FloatRange(min=0),
+    default=120.0,
+    help="Number of seconds to poll while waiting for the web auth flow to be completed. Ignored if --get-auth-url is passed.",
+)
+@click.option(
+    "-i",
+    "--poll-interval",
+    type=click.FloatRange(min=0.5),
+    default=0.5,
+    help="Number of seconds between polling attempts. Ignored if --get-auth-url is passed.",
+)
 @pass_fulcra_api
-def login(fulcra_api: FulcraAPI, get_auth_url: bool, device_code: str | None, poll_timeout: float, poll_interval: float):
+def login(
+    fulcra_api: FulcraAPI,
+    get_auth_url: bool,
+    device_code: str | None,
+    poll_timeout: float,
+    poll_interval: float,
+):
     """Authenticates to the Fulcra Platform.
 
     The OAuth Device Authorization Flow isused to authenticate a user to the Fulcra Life API. Run interactively. A URL will be presented to load in browser. A new browser session will be automatically launched on supported platforms, and this command will poll for a valid token from the completion of the flow for up to two minutes.
@@ -28,7 +59,9 @@ def login(fulcra_api: FulcraAPI, get_auth_url: bool, device_code: str | None, po
     """
 
     if get_auth_url and device_code is not None:
-        raise click.ClickException("--get-auth-url and --device-code are mutually exclusive")
+        raise click.ClickException(
+            "--get-auth-url and --device-code are mutually exclusive"
+        )
 
     if get_auth_url:
         try:
@@ -37,11 +70,15 @@ def login(fulcra_api: FulcraAPI, get_auth_url: bool, device_code: str | None, po
             print(exc)
             raise click.ClickException("Authorization failed, try again.") from exc
 
-        click.echo("Open the web auth URL in a browser, verify the web auth code, and complete the web auth flow.\n")
+        click.echo(
+            "Open the web auth URL in a browser, verify the web auth code, and complete the web auth flow.\n"
+        )
         click.echo(f"Web auth URL: {uri}")
         click.echo(f"- Web auth code: {code}")
         click.echo(f"- Device code: {device_code}\n")
-        click.echo("After finishing the web auth flow, complete authentication with the device code by running:\n")
+        click.echo(
+            "After finishing the web auth flow, complete authentication with the device code by running:\n"
+        )
         click.echo(f"fulcra-api auth login --device-code {device_code}")
         return
 
@@ -50,11 +87,13 @@ def login(fulcra_api: FulcraAPI, get_auth_url: bool, device_code: str | None, po
             creds = fulcra_api.oidc.poll_for_token(
                 device_code=device_code,
                 poll_timeout=datetime.timedelta(seconds=poll_timeout),
-                poll_interval=datetime.timedelta(seconds=poll_interval)
+                poll_interval=datetime.timedelta(seconds=poll_interval),
             )
 
         except Exception as exc:
-            raise click.ClickException(f"Authorization failed, try again: {exc}") from exc
+            raise click.ClickException(
+                f"Authorization failed, try again: {exc}"
+            ) from exc
 
         click.echo("✅ Authorization successful!")
 
@@ -82,7 +121,7 @@ def login(fulcra_api: FulcraAPI, get_auth_url: bool, device_code: str | None, po
     click.echo("✅ Authorization successful!")
 
     save_creds(creds)
-    
+
 
 @auth.command("print-access-token", short_help="Print Fulcra oauth2 access token")
 @pass_fulcra_api

--- a/fulcra_api/cli/auth.py
+++ b/fulcra_api/cli/auth.py
@@ -1,9 +1,11 @@
-import webbrowser
+import datetime
 import sys
+import webbrowser
 
 import click
-import datetime
 
+from ..core import FulcraAPI
+from . import pass_fulcra_api
 from .utils import requires_auth, save_creds
 
 
@@ -17,8 +19,8 @@ def auth():
 @click.option("-d", "--device-code", type=str, default=None, help="Finish authentication with a device code after the browser auth flow is completed")
 @click.option("-p", "--poll-timeout", type=click.FloatRange(min=0), default=120.0, help="Number of seconds to poll while waiting for the web auth flow to be completed. Ignored if --get-auth-url is passed.")
 @click.option("-i", "--poll-interval", type=click.FloatRange(min=0.5), default=0.5, help="Number of seconds between polling attempts. Ignored if --get-auth-url is passed.")
-@click.pass_context
-def login(ctx, get_auth_url: bool, device_code: str | None, poll_timeout: float, poll_interval: float):
+@pass_fulcra_api
+def login(fulcra_api: FulcraAPI, get_auth_url: bool, device_code: str | None, poll_timeout: float, poll_interval: float):
     """Authenticates to the Fulcra Platform.
 
     The OAuth Device Authorization Flow isused to authenticate a user to the Fulcra Life API. Run interactively. A URL will be presented to load in browser. A new browser session will be automatically launched on supported platforms, and this command will poll for a valid token from the completion of the flow for up to two minutes.
@@ -31,7 +33,7 @@ def login(ctx, get_auth_url: bool, device_code: str | None, poll_timeout: float,
 
     if get_auth_url:
         try:
-            device_code, uri, code = ctx.obj.oidc.get_device_code()
+            device_code, uri, code = fulcra_api.oidc.get_device_code()
         except Exception as exc:
             print(exc)
             raise click.ClickException("Authorization failed, try again.") from exc
@@ -43,15 +45,15 @@ def login(ctx, get_auth_url: bool, device_code: str | None, poll_timeout: float,
         click.echo("After finishing the web auth flow, complete authentication with the device code by running:\n")
         click.echo(f"fulcra-api auth login --device-code {device_code}")
         return
-    
+
     if device_code is not None:
         try:
-            creds = ctx.obj.oidc.poll_for_token(
+            creds = fulcra_api.oidc.poll_for_token(
                 device_code=device_code,
                 poll_timeout=datetime.timedelta(seconds=poll_timeout),
                 poll_interval=datetime.timedelta(seconds=poll_interval)
             )
-            
+
         except Exception as exc:
             raise click.ClickException(f"Authorization failed, try again: {exc}") from exc
 
@@ -59,7 +61,7 @@ def login(ctx, get_auth_url: bool, device_code: str | None, poll_timeout: float,
 
         save_creds(creds)
         return
-    
+
     def prompt(device_code: str, uri: str, code: str):
         webbrowser.open_new_tab(uri)
         click.echo(
@@ -70,7 +72,7 @@ def login(ctx, get_auth_url: bool, device_code: str | None, poll_timeout: float,
         )
 
     try:
-        creds = ctx.obj.oidc.authorize_via_device_flow(
+        creds = fulcra_api.oidc.authorize_via_device_flow(
             prompt_callback=prompt,
             poll_timeout=datetime.timedelta(seconds=poll_timeout),
             poll_interval=datetime.timedelta(seconds=poll_interval),
@@ -84,9 +86,9 @@ def login(ctx, get_auth_url: bool, device_code: str | None, poll_timeout: float,
     
 
 @auth.command("print-access-token", short_help="Print Fulcra oauth2 access token")
-@click.pass_context
+@pass_fulcra_api
 @requires_auth
-def get_access_token(ctx):
+def get_access_token(fulcra_api: FulcraAPI):
     """Print a OAuth2 bearer token for use with accessing the Fulcra Life API.
 
     This is useful for making direct calls to the Fulcra Life API.
@@ -95,6 +97,6 @@ def get_access_token(ctx):
     EXAMPLE:
         curl --oauth2-bearer "$(fulcra auth print-access-token)" 'https://api.fulcradynamics.com/user/v1alpha1/info'
     """
-    if ctx.obj.fulcra_credentials.is_expired():
-        ctx.obj.refresh_access_token()
-    click.echo(ctx.obj.fulcra_credentials.access_token)
+    if fulcra_api.fulcra_credentials.is_expired():
+        fulcra_api.refresh_access_token()
+    click.echo(fulcra_api.fulcra_credentials.access_token)

--- a/fulcra_api/cli/auth.py
+++ b/fulcra_api/cli/auth.py
@@ -5,8 +5,7 @@ import webbrowser
 import click
 
 from ..core import FulcraAPI
-from . import pass_fulcra_api
-from .utils import requires_auth, save_creds
+from .utils import pass_fulcra_api, requires_auth, save_creds
 
 
 @click.group(help="Authentication sub-commands")

--- a/fulcra_api/cli/commands.py
+++ b/fulcra_api/cli/commands.py
@@ -6,17 +6,19 @@ from uuid import UUID
 
 import click
 
+from ..core import FulcraAPI
+from . import pass_fulcra_api
 from .utils import parse_time, related_cli_commands, requires_auth, time_range
 
 
 @click.command("calendars", short_help="Return Apple calendars")
-@click.pass_context
+@pass_fulcra_api
 @requires_auth
-def list_calendars(ctx):
+def list_calendars(fulcra_api: FulcraAPI):
     """Return Apple Calendar records."""
 
     try:
-        results = ctx.obj.calendars()
+        results = fulcra_api.calendars()
     except HTTPError as exc:
         raise click.ClickException(exc)
 
@@ -26,15 +28,15 @@ def list_calendars(ctx):
 
 @click.command("calendar-events", short_help="Return Apple calendar events")
 @time_range
-@click.pass_context
+@pass_fulcra_api
 @requires_auth
-def list_calendar_events(ctx, start_time: datetime, end_time: datetime):
+def list_calendar_events(fulcra_api: FulcraAPI, start_time: datetime, end_time: datetime):
     """Return Apple Calendar Event records across TIME_RANGE.
 
     TIME_RANGE: Two start & end date arguments in ISO8601 format or a single interval argument relative to the current time ("1 week", "2 days", "3h", etc.)
     """
     try:
-        results = ctx.obj.calendar_events(start_time, end_time)
+        results = fulcra_api.calendar_events(start_time, end_time)
     except HTTPError as exc:
         raise click.ClickException(exc)
 
@@ -44,16 +46,16 @@ def list_calendar_events(ctx, start_time: datetime, end_time: datetime):
 
 @click.command("apple-workouts", short_help="Return Apple workouts")
 @time_range
-@click.pass_context
+@pass_fulcra_api
 @requires_auth
-def list_apple_workouts(ctx, start_time: datetime, end_time: datetime):
+def list_apple_workouts(fulcra_api: FulcraAPI, start_time: datetime, end_time: datetime):
     """Return Apple Workout records across TIME_RANGE.
 
     TIME_RANGE: Two start & end date arguments in ISO8601 format or a single interval argument relative to the current time ("1 week", "2 days", "3h", etc.)
     """
 
     try:
-        results = ctx.obj.apple_workouts(start_time, end_time)
+        results = fulcra_api.apple_workouts(start_time, end_time)
     except HTTPError as exc:
         raise click.ClickException(exc)
 
@@ -88,10 +90,10 @@ def list_apple_workouts(ctx, start_time: datetime, end_time: datetime):
     default=None,
     help="Aggregate functions (max, min, delta, mean, uniques, allpoints, rollingmean) to apply to time series window, can be passed multiple times.",
 )
-@click.pass_context
+@pass_fulcra_api
 @requires_auth
 def metric_time_series(
-    ctx,
+    fulcra_api: FulcraAPI,
     metric: str,
     start_time: datetime,
     end_time: datetime,
@@ -109,7 +111,7 @@ def metric_time_series(
 
     """
     try:
-        data_type = ctx.obj.v1_catalog(metric)
+        data_type = fulcra_api.v1_catalog(metric)
     except HTTPError as exc:
         if exc.code == 404:
             raise click.ClickException("Type not found")
@@ -118,10 +120,10 @@ def metric_time_series(
 
     if data_type[0]["api_version"] != "v0" or data_type[0]["class"] != "metric":
         raise click.ClickException(
-            f"{data_type[0]['id']} cannot be returned with metric-time-series, use `{ctx.find_root().info_name} get-records {metric}` instead to return raw sample records."
+            f"{data_type[0]['id']} cannot be returned with metric-time-series, use `fulcra get-records {metric}` instead to return raw sample records."
         )
 
-    df = ctx.obj.metric_time_series(
+    df = fulcra_api.metric_time_series(
         start_time,
         end_time,
         metric,
@@ -140,16 +142,16 @@ def metric_time_series(
     "google-location-updates", short_help="Return Google Maps location update records"
 )
 @time_range
-@click.pass_context
+@pass_fulcra_api
 @requires_auth
-def google_location_updates(ctx, start_time: datetime, end_time: datetime):
+def google_location_updates(fulcra_api: FulcraAPI, start_time: datetime, end_time: datetime):
     """Return raw Google location update sample records across TIME_RANGE.
 
     TIME_RANGE: Two start & end date arguments in ISO8601 format or a single interval argument relative to the current time ("1 week", "2 days", "3h", etc.)
     """
 
     try:
-        results = ctx.obj.gmaps_location_updates(start_time, end_time)
+        results = fulcra_api.gmaps_location_updates(start_time, end_time)
     except HTTPError as exc:
         raise click.ClickException(exc)
 
@@ -161,16 +163,16 @@ def google_location_updates(ctx, start_time: datetime, end_time: datetime):
     "apple-location-updates", short_help="Return Apple location update records"
 )
 @time_range
-@click.pass_context
+@pass_fulcra_api
 @requires_auth
-def apple_location_updates(ctx, start_time: datetime, end_time: datetime):
+def apple_location_updates(fulcra_api: FulcraAPI, start_time: datetime, end_time: datetime):
     """Return raw Apple location update sample records across TIME_RANGE.
 
     TIME_RANGE: Two start & end date arguments in ISO8601 format or a single interval argument relative to the current time ("1 week", "2 days", "3h", etc.)
     """
 
     try:
-        results = ctx.obj.apple_location_updates(start_time, end_time)
+        results = fulcra_api.apple_location_updates(start_time, end_time)
     except HTTPError as exc:
         raise click.ClickException(exc)
 
@@ -182,16 +184,16 @@ def apple_location_updates(ctx, start_time: datetime, end_time: datetime):
     "apple-location-visits", short_help="Return Apple location visit records"
 )
 @time_range
-@click.pass_context
+@pass_fulcra_api
 @requires_auth
-def apple_location_visits(ctx, start_time: datetime, end_time: datetime):
+def apple_location_visits(fulcra_api: FulcraAPI, start_time: datetime, end_time: datetime):
     """Return raw Apple location visit sample records across TIME_RANGE.
 
     TIME_RANGE: Two start & end date arguments in ISO8601 format or a single interval argument relative to the current time ("1 week", "2 days", "3h", etc.)
     """
 
     try:
-        results = ctx.obj.apple_location_visits(start_time, end_time)
+        results = fulcra_api.apple_location_visits(start_time, end_time)
     except HTTPError as exc:
         raise click.ClickException(exc)
 
@@ -224,10 +226,10 @@ def apple_location_visits(ctx, start_time: datetime, end_time: datetime):
     default=False,
     help="Reverse geolocate coordinates.",
 )
-@click.pass_context
+@pass_fulcra_api
 @requires_auth
 def location_time_series(
-    ctx,
+    fulcra_api: FulcraAPI,
     start_time: datetime,
     end_time: datetime,
     change_meters: int,
@@ -240,7 +242,7 @@ def location_time_series(
     TIME_RANGE: Two start & end date arguments in ISO8601 format or a single interval argument relative to the current time ("1 week", "2 days", "3h", etc.)
     """
     try:
-        results = ctx.obj.location_time_series(
+        results = fulcra_api.location_time_series(
             start_time, end_time, change_meters, sample_rate, look_back, reverse_geocode
         )
     except HTTPError as exc:
@@ -272,10 +274,10 @@ def location_time_series(
     default=False,
     help="Reverse geolocate coordinates.",
 )
-@click.pass_context
+@pass_fulcra_api
 @requires_auth
 def location_at_time(
-    ctx,
+    fulcra_api: FulcraAPI,
     time: datetime,
     window_size: int,
     include_after: bool,
@@ -289,7 +291,7 @@ def location_at_time(
     """
 
     try:
-        results = ctx.obj.location_at_time(
+        results = fulcra_api.location_at_time(
             time, window_size, include_after, reverse_geocode
         )
     except HTTPError as exc:
@@ -342,10 +344,10 @@ def location_at_time(
     default=False,
     help="Do not clip the data to the requested date range.",
 )
-@click.pass_context
+@pass_fulcra_api
 @requires_auth
 def sleep_stages(
-    ctx,
+    fulcra_api: FulcraAPI,
     start_time: datetime,
     end_time: datetime,
     cycle_gap: str,
@@ -392,7 +394,7 @@ def sleep_stages(
         kwargs["clip_to_range"] = False
 
     try:
-        df = ctx.obj.sleep_stages(**kwargs)
+        df = fulcra_api.sleep_stages(**kwargs)
     except HTTPError as exc:
         raise click.ClickException(exc)
 
@@ -432,10 +434,10 @@ def sleep_stages(
     default=False,
     help="Do not clip the data to the requested date range.",
 )
-@click.pass_context
+@pass_fulcra_api
 @requires_auth
 def sleep_cycles(
-    ctx,
+    fulcra_api: FulcraAPI,
     start_time: datetime,
     end_time: datetime,
     cycle_gap: Optional[str],
@@ -463,7 +465,7 @@ def sleep_cycles(
         kwargs["clip_to_range"] = False
 
     try:
-        df = ctx.obj.sleep_cycles(**kwargs)
+        df = fulcra_api.sleep_cycles(**kwargs)
     except HTTPError as exc:
         raise click.ClickException(exc)
 
@@ -523,10 +525,10 @@ def sleep_cycles(
     default=False,
     help="Do not clip the data to the requested date range.",
 )
-@click.pass_context
+@pass_fulcra_api
 @requires_auth
 def sleep_cycles_aggregated(
-    ctx,
+    fulcra_api: FulcraAPI,
     start_time: datetime,
     end_time: datetime,
     cycle_gap: Optional[str],
@@ -565,7 +567,7 @@ def sleep_cycles_aggregated(
         kwargs["agg_functions"] = list(function)
 
     try:
-        df = ctx.obj.sleep_agg(**kwargs)
+        df = fulcra_api.sleep_agg(**kwargs)
     except HTTPError as exc:
         raise click.ClickException(exc)
 
@@ -584,10 +586,10 @@ def sleep_cycles_aggregated(
     default=None,
     help="Fulcra user ID to query data for (requires an active datashare from that user).",
 )
-@click.pass_context
+@pass_fulcra_api
 @requires_auth
 def get_records(
-    ctx,
+    fulcra_api: FulcraAPI,
     data_type: str,
     start_time: datetime,
     end_time: datetime,
@@ -625,7 +627,7 @@ def get_records(
             )
 
     try:
-        data_type = ctx.obj.v1_catalog(data_type)
+        data_type = fulcra_api.v1_catalog(data_type)
     except HTTPError as exc:
         if exc.code == 404:
             raise click.ClickException("Type not found")
@@ -640,7 +642,7 @@ def get_records(
             dt["api_version"] == "v0"
             and record_type == "metric"
         ):
-            query_func = ctx.obj.metric_samples
+            query_func = fulcra_api.metric_samples
             kwargs = {
                 "start_time": start_time,
                 "end_time": end_time,
@@ -649,7 +651,7 @@ def get_records(
             if user_id:
                 kwargs["fulcra_userid"] = user_id
         elif dt["api_version"] == "v1alpha1" and record_type == "metric":
-            query_func = ctx.obj.fulcra_v1_api_path
+            query_func = fulcra_api.fulcra_v1_api_path
             path = f"{record_type}/{dt['id']}"
             if user_annotation_id:
                 path = f"{path}/{user_annotation_id}"
@@ -658,7 +660,7 @@ def get_records(
                 params["fulcra_userid"] = user_id
             kwargs = {"path": path, "params": params}
         elif dt["api_version"] == "v1alpha1" and record_type == "event":
-            query_func = ctx.obj.fulcra_v1_api_path
+            query_func = fulcra_api.fulcra_v1_api_path
             path = f"{record_type}/{dt['id']}"
             if user_annotation_id:
                 path = f"{path}/{user_annotation_id}"
@@ -689,10 +691,10 @@ def get_records(
 @click.option("-n", "--name", type=str, help="Filter results by partial name.")
 @click.option("--base-types-only", is_flag=True, default=False)
 @click.option("-c", "--category", type=str, help="Filter by category.")
-@click.pass_context
+@pass_fulcra_api
 @requires_auth
 def catalog(
-    ctx,
+    fulcra_api: FulcraAPI,
     base_types_only: bool,
     data_type: str | None = None,
     name: str | None = None,
@@ -712,7 +714,7 @@ def catalog(
         else:
             catalog_category = None
 
-        response = ctx.obj.v1_catalog(data_type=data_type, category=catalog_category)
+        response = fulcra_api.v1_catalog(data_type=data_type, category=catalog_category)
     except HTTPError as exc:
         if exc.code == 404:
             raise click.ClickException("Type not found")
@@ -730,12 +732,12 @@ def catalog(
 @click.command(
     "user-info", short_help="Return information about the authenticated user"
 )
-@click.pass_context
+@pass_fulcra_api
 @requires_auth
-def user_info(ctx):
+def user_info(fulcra_api: FulcraAPI):
     """Return user information object for authenticated user"""
     try:
-        resp = ctx.obj.get_user_info()
+        resp = fulcra_api.get_user_info()
     except HTTPError as exc:
         raise click.ClickException(exc) from exc
 
@@ -746,9 +748,9 @@ def user_info(ctx):
     "data-updates", short_help="Return data/file updates that occurred during a period"
 )
 @time_range
-@click.pass_context
+@pass_fulcra_api
 @requires_auth
-def data_updates(ctx, start_time: datetime, end_time: datetime):
+def data_updates(fulcra_api: FulcraAPI, start_time: datetime, end_time: datetime):
     """Return a summary of the data that was updated across TIME_RANGE.
 
     TIME_RANGE: Two start & end date arguments in ISO8601 format or a single interval argument relative to the current time ("1 week", "2 days", "3h", etc.)
@@ -757,7 +759,7 @@ def data_updates(ctx, start_time: datetime, end_time: datetime):
     the number of records processed for each) and any uploaded files that changed.
     """
     try:
-        resp = ctx.obj.data_updates(start_time, end_time)
+        resp = fulcra_api.data_updates(start_time, end_time)
     except HTTPError as exc:
         raise click.ClickException(exc) from exc
 

--- a/fulcra_api/cli/commands.py
+++ b/fulcra_api/cli/commands.py
@@ -7,8 +7,7 @@ from uuid import UUID
 import click
 
 from ..core import FulcraAPI
-from . import pass_fulcra_api
-from .utils import parse_time, related_cli_commands, requires_auth, time_range
+from .utils import parse_time, pass_fulcra_api, related_cli_commands, requires_auth, time_range
 
 
 @click.command("calendars", short_help="Return Apple calendars")

--- a/fulcra_api/cli/commands.py
+++ b/fulcra_api/cli/commands.py
@@ -6,8 +6,15 @@ from uuid import UUID
 
 import click
 
-from ..core import FulcraAPI
-from .utils import parse_time, pass_fulcra_api, related_cli_commands, requires_auth, time_range
+from fulcra_api.core import FulcraAPI
+
+from .utils import (
+    parse_time,
+    pass_fulcra_api,
+    related_cli_commands,
+    requires_auth,
+    time_range,
+)
 
 
 @click.command("calendars", short_help="Return Apple calendars")
@@ -29,7 +36,9 @@ def list_calendars(fulcra_api: FulcraAPI):
 @time_range
 @pass_fulcra_api
 @requires_auth
-def list_calendar_events(fulcra_api: FulcraAPI, start_time: datetime, end_time: datetime):
+def list_calendar_events(
+    fulcra_api: FulcraAPI, start_time: datetime, end_time: datetime
+):
     """Return Apple Calendar Event records across TIME_RANGE.
 
     TIME_RANGE: Two start & end date arguments in ISO8601 format or a single interval argument relative to the current time ("1 week", "2 days", "3h", etc.)
@@ -47,7 +56,9 @@ def list_calendar_events(fulcra_api: FulcraAPI, start_time: datetime, end_time: 
 @time_range
 @pass_fulcra_api
 @requires_auth
-def list_apple_workouts(fulcra_api: FulcraAPI, start_time: datetime, end_time: datetime):
+def list_apple_workouts(
+    fulcra_api: FulcraAPI, start_time: datetime, end_time: datetime
+):
     """Return Apple Workout records across TIME_RANGE.
 
     TIME_RANGE: Two start & end date arguments in ISO8601 format or a single interval argument relative to the current time ("1 week", "2 days", "3h", etc.)
@@ -143,7 +154,9 @@ def metric_time_series(
 @time_range
 @pass_fulcra_api
 @requires_auth
-def google_location_updates(fulcra_api: FulcraAPI, start_time: datetime, end_time: datetime):
+def google_location_updates(
+    fulcra_api: FulcraAPI, start_time: datetime, end_time: datetime
+):
     """Return raw Google location update sample records across TIME_RANGE.
 
     TIME_RANGE: Two start & end date arguments in ISO8601 format or a single interval argument relative to the current time ("1 week", "2 days", "3h", etc.)
@@ -164,7 +177,9 @@ def google_location_updates(fulcra_api: FulcraAPI, start_time: datetime, end_tim
 @time_range
 @pass_fulcra_api
 @requires_auth
-def apple_location_updates(fulcra_api: FulcraAPI, start_time: datetime, end_time: datetime):
+def apple_location_updates(
+    fulcra_api: FulcraAPI, start_time: datetime, end_time: datetime
+):
     """Return raw Apple location update sample records across TIME_RANGE.
 
     TIME_RANGE: Two start & end date arguments in ISO8601 format or a single interval argument relative to the current time ("1 week", "2 days", "3h", etc.)
@@ -185,7 +200,9 @@ def apple_location_updates(fulcra_api: FulcraAPI, start_time: datetime, end_time
 @time_range
 @pass_fulcra_api
 @requires_auth
-def apple_location_visits(fulcra_api: FulcraAPI, start_time: datetime, end_time: datetime):
+def apple_location_visits(
+    fulcra_api: FulcraAPI, start_time: datetime, end_time: datetime
+):
     """Return raw Apple location visit sample records across TIME_RANGE.
 
     TIME_RANGE: Two start & end date arguments in ISO8601 format or a single interval argument relative to the current time ("1 week", "2 days", "3h", etc.)
@@ -637,10 +654,7 @@ def get_records(
 
     for dt in data_type:
         record_type = dt.get("record_spec", {}).get("type")
-        if (
-            dt["api_version"] == "v0"
-            and record_type == "metric"
-        ):
+        if dt["api_version"] == "v0" and record_type == "metric":
             query_func = fulcra_api.metric_samples
             kwargs = {
                 "start_time": start_time,

--- a/fulcra_api/cli/data_types.py
+++ b/fulcra_api/cli/data_types.py
@@ -141,7 +141,6 @@ def data_type_create(
                 raise click.BadOptionUsage(
                     "unit",
                     f"-u / --unit cannot be used with base data type {base_data_type}",
-                    ctx,
                 )
             if raw_value is not None:
                 value = click.types.BoolParamType().convert(raw_value, None, None)
@@ -155,14 +154,12 @@ def data_type_create(
                 raise click.BadOptionUsage(
                     "scale_labels",
                     f"-s / --scale-labels must be used with exactly 5 values with base data type {base_data_type}",
-                    ctx,
                 )
             # user-service does not accept a unit for scale annotations
             if unit is not None:
                 raise click.BadOptionUsage(
                     "unit",
                     f"-u / --unit cannot be used with base data type {base_data_type}",
-                    ctx,
                 )
         case _:
             raise click.ClickException(f"Unsupported base type: {base_data_type}")

--- a/fulcra_api/cli/data_types.py
+++ b/fulcra_api/cli/data_types.py
@@ -6,8 +6,7 @@ from uuid import UUID
 import click
 
 from ..core import FulcraAPI
-from . import pass_fulcra_api
-from .utils import requires_auth
+from .utils import pass_fulcra_api, requires_auth
 
 
 @click.group(name="data-type", help="Data type management sub-commands")

--- a/fulcra_api/cli/data_types.py
+++ b/fulcra_api/cli/data_types.py
@@ -5,6 +5,8 @@ from uuid import UUID
 
 import click
 
+from ..core import FulcraAPI
+from . import pass_fulcra_api
 from .utils import requires_auth
 
 
@@ -57,10 +59,10 @@ def data_type():
 @click.option(
     "--add-to-timeline", is_flag=True, help="Add created data type to timeline"
 )
-@click.pass_context
+@pass_fulcra_api
 @requires_auth
 def data_type_create(
-    ctx,
+    fulcra_api: FulcraAPI,
     base_data_type: str,
     name: str,
     description: Optional[str],
@@ -81,7 +83,7 @@ def data_type_create(
     """
 
     try:
-        catalog_resp = ctx.obj.v1_catalog(base_data_type)
+        catalog_resp = fulcra_api.v1_catalog(base_data_type)
     except HTTPError as exc:
         raise click.ClickException(f"Failed to validate BASE_DATA_TYPE: {exc}")
 
@@ -105,21 +107,18 @@ def data_type_create(
             raise click.BadOptionUsage(
                 "metric_kind",
                 f"-k / --kind cannot be used with base data type {base_data_type}",
-                ctx,
             )
 
         if raw_value is not None:
             raise click.BadOptionUsage(
                 "raw_value",
                 f"-v / --value cannot be used with base data type {base_data_type}",
-                ctx,
             )
 
         if unit is not None:
             raise click.BadOptionUsage(
                 "unit",
                 f"-u / --unit cannot be used with base data type {base_data_type}",
-                ctx,
             )
 
     # TODO: Possibly update type metadata to be able to determine that this is a scale
@@ -127,7 +126,6 @@ def data_type_create(
         raise click.BadOptionUsage(
             "scale_labels",
             f"-s / --scale-labels cannot be used with base data type {base_data_type}",
-            ctx,
         )
 
     value = None
@@ -170,7 +168,7 @@ def data_type_create(
             raise click.ClickException(f"Unsupported base type: {base_data_type}")
 
     try:
-        ann = ctx.obj.create_annotation(
+        ann = fulcra_api.create_annotation(
             annotation_type=annotation_type,
             name=name,
             description=description,
@@ -183,7 +181,7 @@ def data_type_create(
 
         if add_to_timeline:
             try:
-                info = ctx.obj.get_user_info()
+                info = fulcra_api.get_user_info()
                 current_prefs = info.get("preferences", {})
                 existing_metrics_map = current_prefs.get("selected_metrics_map", {})
 
@@ -202,7 +200,7 @@ def data_type_create(
                     }
                 }
 
-                ctx.obj.update_user_preferences(prefs_payload)
+                fulcra_api.update_user_preferences(prefs_payload)
             except HTTPError as exc:
                 click.echo(f"Failed to add annotation to timeline: {exc}", err=True)
 
@@ -216,9 +214,9 @@ def data_type_create(
 
 @data_type.command("archive", short_help="Archive a user-defined data type")
 @click.argument("data_type")
-@click.pass_context
+@pass_fulcra_api
 @requires_auth
-def data_type_archive(ctx, data_type: str):
+def data_type_archive(fulcra_api: FulcraAPI, data_type: str):
     """
     Archive a user-defined data type by ID.
 
@@ -226,7 +224,7 @@ def data_type_archive(ctx, data_type: str):
     """
 
     try:
-        filtered_types = ctx.obj.v1_catalog(data_type=data_type)
+        filtered_types = fulcra_api.v1_catalog(data_type=data_type)
     except HTTPError:
         raise click.ClickException(f"Could not find data type matching id: {data_type}")
 
@@ -246,7 +244,7 @@ def data_type_archive(ctx, data_type: str):
         raise click.ClickException("DATA_TYPE must be <Annotation Type>/<UUID>")
 
     try:
-        ctx.obj.delete_annotation(annotation_id=ann_id)
+        fulcra_api.delete_annotation(annotation_id=ann_id)
         click.echo(f"Archived data type: {data_type}")
     except HTTPError as exc:
         raise click.ClickException(f"Failed to archive data type {data_type}: {exc}")
@@ -254,9 +252,9 @@ def data_type_archive(ctx, data_type: str):
 
 @data_type.command("restore", short_help="Restore an archived user-defined data type")
 @click.argument("data_type")
-@click.pass_context
+@pass_fulcra_api
 @requires_auth
-def restore_data_type(ctx, data_type: str):
+def restore_data_type(fulcra_api: FulcraAPI, data_type: str):
     """
     Restore an archived user-defined data type by ID.
 
@@ -264,7 +262,7 @@ def restore_data_type(ctx, data_type: str):
     """
 
     try:
-        filtered_types = ctx.obj.v1_catalog(data_type=data_type)
+        filtered_types = fulcra_api.v1_catalog(data_type=data_type)
     except HTTPError:
         raise click.ClickException(f"Could not find data type matching id: {data_type}")
 
@@ -284,7 +282,7 @@ def restore_data_type(ctx, data_type: str):
         raise click.ClickException("DATA_TYPE must be <Annotation Type>/<UUID>")
 
     try:
-        ann = ctx.obj.restore_annotation(annotation_id=ann_id)
+        ann = fulcra_api.restore_annotation(annotation_id=ann_id)
         click.echo(json.dumps(ann))
     except HTTPError as exc:
         raise click.ClickException(f"Failed to restore data type {data_type}: {exc}")

--- a/fulcra_api/cli/data_types.py
+++ b/fulcra_api/cli/data_types.py
@@ -5,7 +5,8 @@ from uuid import UUID
 
 import click
 
-from ..core import FulcraAPI
+from fulcra_api.core import FulcraAPI
+
 from .utils import pass_fulcra_api, requires_auth
 
 

--- a/fulcra_api/cli/files.py
+++ b/fulcra_api/cli/files.py
@@ -7,6 +7,8 @@ from uuid import UUID
 import click
 import puremagic
 
+from ..core import FulcraAPI
+from . import pass_fulcra_api
 from .utils import human_size, make_filepath, requires_auth
 
 
@@ -17,9 +19,9 @@ def file():
 
 @file.command("list", short_help="List files")
 @click.argument("path", type=str, default="/")
-@click.pass_context
+@pass_fulcra_api
 @requires_auth
-def file_list(ctx, path: str):
+def file_list(fulcra_api: FulcraAPI, path: str):
     """List uploaded files.
 
     PATH: Path to list files in [Default: /]
@@ -27,7 +29,7 @@ def file_list(ctx, path: str):
 
     path = make_filepath(path)
 
-    results = ctx.obj.list_files(path)
+    results = fulcra_api.list_files(path)
 
     if results.get("folders") is not None:
         for d in results.get("folders", []):
@@ -46,9 +48,9 @@ def file_list(ctx, path: str):
 
 @file.command("stat", short_help="Get information about a file")
 @click.argument("path", type=str)
-@click.pass_context
+@pass_fulcra_api
 @requires_auth
-def file_stat(ctx, path: str):
+def file_stat(fulcra_api: FulcraAPI, path: str):
     """Returns information about an uploaded file, including size, date uploaded, and all previously uploaded versions of the file.
 
     PATH: Full path of the file.
@@ -57,7 +59,7 @@ def file_stat(ctx, path: str):
     path = make_filepath(path)
 
     try:
-        f = ctx.obj.resolve_filepath(path, all_versions=True)
+        f = fulcra_api.resolve_filepath(path, all_versions=True)
     except Exception as exc:
         raise click.ClickException(exc)
 
@@ -78,9 +80,9 @@ def file_stat(ctx, path: str):
 @file.command("download", short_help="Download a file")
 @click.argument("remote_file", type=str)
 @click.argument("local_file", type=click.File(mode="wb"), required=False, default=None)
-@click.pass_context
+@pass_fulcra_api
 @requires_auth
-def file_download(ctx, remote_file: str, local_file=None):
+def file_download(fulcra_api: FulcraAPI, remote_file: str, local_file=None):
     """Download a file.
 
     REMOTE_FILE: Full path of file to download.
@@ -91,11 +93,11 @@ def file_download(ctx, remote_file: str, local_file=None):
     remote_file = make_filepath(remote_file)
 
     try:
-        f = ctx.obj.resolve_filepath(remote_file)
+        f = fulcra_api.resolve_filepath(remote_file)
     except Exception as exc:
         raise click.ClickException(exc)
 
-    resp = ctx.obj.download_file(f[0].get("id"))
+    resp = fulcra_api.download_file(f[0].get("id"))
 
     if local_file is None:
         local_file = click.open_file(pathlib.PurePath(f[0].get("name")).name, mode="wb")
@@ -109,9 +111,9 @@ def file_download(ctx, remote_file: str, local_file=None):
 @file.command("upload", short_help="Upload a file")
 @click.argument("local_file", type=click.File(mode="rb"))
 @click.argument("remote_file", type=str, default="")
-@click.pass_context
+@pass_fulcra_api
 @requires_auth
-def file_upload(ctx, local_file: click.File, remote_file: str):
+def file_upload(fulcra_api: FulcraAPI, local_file: click.File, remote_file: str):
     """Upload a file.
 
     LOCAL_FILE: File to upload.
@@ -133,7 +135,7 @@ def file_upload(ctx, local_file: click.File, remote_file: str):
         file_type = "application/octet-stream"
 
     try:
-        new_file = ctx.obj.upload_file(local_file, file_type, file_size, path)
+        new_file = fulcra_api.upload_file(local_file, file_type, file_size, path)
         full_path = make_filepath(new_file["file"]["path"], new_file["file"]["name"])
     except HTTPError as exc:
         raise click.ClickException(exc.fp.read())
@@ -143,9 +145,9 @@ def file_upload(ctx, local_file: click.File, remote_file: str):
 
 @file.command("delete", short_help="Delete a file")
 @click.argument("path", type=str)
-@click.pass_context
+@pass_fulcra_api
 @requires_auth
-def file_delete(ctx, path):
+def file_delete(fulcra_api: FulcraAPI, path):
     """Delete a file.
 
     PATH: Path of the file to delete.
@@ -153,27 +155,27 @@ def file_delete(ctx, path):
     path = make_filepath(path)
 
     try:
-        f = ctx.obj.resolve_filepath(path)
+        f = fulcra_api.resolve_filepath(path)
     except Exception as exc:
         raise click.ClickException(exc)
 
-    ctx.obj.delete_file(f[0].get("id"))
+    fulcra_api.delete_file(f[0].get("id"))
 
     click.echo(f"❌ fulcra:{path}")
 
 
 @file.command("restore", short_help="Restore a file")
 @click.argument("version_id", type=UUID)
-@click.pass_context
+@pass_fulcra_api
 @requires_auth
-def file_restore(ctx, version_id):
+def file_restore(fulcra_api: FulcraAPI, version_id):
     """Restore a previous version of a file.
 
     VERSION_ID: UUID of the file version you want to restore. Versions are returned via the `file stat` command.
     """
 
     try:
-        file_version = ctx.obj.get_file_by_version(version_id)
+        file_version = fulcra_api.get_file_by_version(version_id)
     except HTTPError as exc:
         if exc.status == 404:
             raise click.ClickException(f"File version {version_id} not found")
@@ -182,7 +184,7 @@ def file_restore(ctx, version_id):
 
     full_file_name = make_filepath(file_version["path"], file_version["name"])
 
-    new_file = ctx.obj.restore_file(file_version["id"])
+    new_file = fulcra_api.restore_file(file_version["id"])
 
     click.echo(
         f"fulcra:{full_file_name}  {file_version['id']} ({file_version['uploaded_at']}) ➡️ {new_file['id']} ({new_file['uploaded_at']})"

--- a/fulcra_api/cli/files.py
+++ b/fulcra_api/cli/files.py
@@ -8,8 +8,7 @@ import click
 import puremagic
 
 from ..core import FulcraAPI
-from . import pass_fulcra_api
-from .utils import human_size, make_filepath, requires_auth
+from .utils import human_size, make_filepath, pass_fulcra_api, requires_auth
 
 
 @click.group(help="File management sub-commands")

--- a/fulcra_api/cli/files.py
+++ b/fulcra_api/cli/files.py
@@ -7,7 +7,8 @@ from uuid import UUID
 import click
 import puremagic
 
-from ..core import FulcraAPI
+from fulcra_api.core import FulcraAPI
+
 from .utils import human_size, make_filepath, pass_fulcra_api, requires_auth
 
 

--- a/fulcra_api/cli/tags.py
+++ b/fulcra_api/cli/tags.py
@@ -5,8 +5,7 @@ from urllib.error import HTTPError
 import click
 
 from ..core import FulcraAPI
-from . import pass_fulcra_api
-from .utils import requires_auth
+from .utils import pass_fulcra_api, requires_auth
 
 
 @click.group(help="Tag management sub-commands")

--- a/fulcra_api/cli/tags.py
+++ b/fulcra_api/cli/tags.py
@@ -4,7 +4,8 @@ from urllib.error import HTTPError
 
 import click
 
-from ..core import FulcraAPI
+from fulcra_api.core import FulcraAPI
+
 from .utils import pass_fulcra_api, requires_auth
 
 
@@ -19,7 +20,12 @@ def tag():
 @click.option("--tag-id", type=str, help="Filter results by tag ID.")
 @pass_fulcra_api
 @requires_auth
-def tag_list(fulcra_api: FulcraAPI, name: Optional[str], tag_name: Optional[str], tag_id: Optional[str]):
+def tag_list(
+    fulcra_api: FulcraAPI,
+    name: Optional[str],
+    tag_name: Optional[str],
+    tag_id: Optional[str],
+):
     """
     Return a list of user-defined tags that can be used when creating and recording custom data types.
     """

--- a/fulcra_api/cli/tags.py
+++ b/fulcra_api/cli/tags.py
@@ -4,6 +4,8 @@ from urllib.error import HTTPError
 
 import click
 
+from ..core import FulcraAPI
+from . import pass_fulcra_api
 from .utils import requires_auth
 
 
@@ -16,15 +18,15 @@ def tag():
 @click.option("-n", "--name", type=str, help="Filter results by partial name.")
 @click.option("--tag-name", type=str, help="Filter results by full tag name.")
 @click.option("--tag-id", type=str, help="Filter results by tag ID.")
-@click.pass_context
+@pass_fulcra_api
 @requires_auth
-def tag_list(ctx, name: Optional[str], tag_name: Optional[str], tag_id: Optional[str]):
+def tag_list(fulcra_api: FulcraAPI, name: Optional[str], tag_name: Optional[str], tag_id: Optional[str]):
     """
     Return a list of user-defined tags that can be used when creating and recording custom data types.
     """
 
     try:
-        response = ctx.obj.tags()
+        response = fulcra_api.tags()
 
         if name:
             response = [
@@ -48,9 +50,9 @@ def tag_list(ctx, name: Optional[str], tag_name: Optional[str], tag_id: Optional
 
 @tag.command("get", short_help="Get a user-defined tag")
 @click.argument("name_or_id", type=str)
-@click.pass_context
+@pass_fulcra_api
 @requires_auth
-def get_tag(ctx, name_or_id: str):
+def get_tag(fulcra_api: FulcraAPI, name_or_id: str):
     """Get a user-defined tag by name or ID.
 
     NAME_OR_ID: Tag name or ID
@@ -66,10 +68,10 @@ def get_tag(ctx, name_or_id: str):
 
     try:
         if tag_id:
-            resp = ctx.obj.get_tag_by_id(tag_id=tag_id)
+            resp = fulcra_api.get_tag_by_id(tag_id=tag_id)
             click.echo(json.dumps(resp))
         else:
-            resp = ctx.obj.get_tag_by_name(name=tag_name)
+            resp = fulcra_api.get_tag_by_name(name=tag_name)
             click.echo(json.dumps(resp))
 
     except HTTPError as exc:
@@ -81,9 +83,9 @@ def get_tag(ctx, name_or_id: str):
 
 @tag.command("create", short_help="Create user-defined tags")
 @click.argument("names", nargs=-1)
-@click.pass_context
+@pass_fulcra_api
 @requires_auth
-def tag_create(ctx, names: Tuple[str, ...]):
+def tag_create(fulcra_api: FulcraAPI, names: Tuple[str, ...]):
     """
     Create case-insensitive user-defined tags by name that can be used when creating and recording custom data types.
     """
@@ -93,7 +95,7 @@ def tag_create(ctx, names: Tuple[str, ...]):
     for name in names:
         tag_name = name.lower()
         try:
-            resp = ctx.obj.create_tag(tag_name)
+            resp = fulcra_api.create_tag(tag_name)
             created_tags.append(resp)
         except HTTPError as exc:
             if exc.status == 409:
@@ -105,15 +107,15 @@ def tag_create(ctx, names: Tuple[str, ...]):
 
 @tag.command("delete", short_help="Delete user-defined tag")
 @click.argument("tag_id")
-@click.pass_context
+@pass_fulcra_api
 @requires_auth
-def tag_delete(ctx, tag_id: str):
+def tag_delete(fulcra_api: FulcraAPI, tag_id: str):
     """
     Delete a user-defined tag by tag ID.
     """
 
     try:
-        ctx.obj.delete_tag(tag_id)
+        fulcra_api.delete_tag(tag_id)
     except HTTPError as exc:
         raise click.ClickException(f"Failed to delete tag {tag_id}: {exc}")
 

--- a/fulcra_api/cli/utils.py
+++ b/fulcra_api/cli/utils.py
@@ -34,12 +34,12 @@ def save_creds(creds: FulcraCredentials):
 
 def requires_auth(f):
     @wraps(f)
-    def wrapper(ctx, *args, **kwargs):
-        if ctx.obj.fulcra_credentials is None:
+    def wrapper(fulcra_api, *args, **kwargs):
+        if fulcra_api.fulcra_credentials is None:
             raise click.ClickException(
-                f"No credentials found, please run `{ctx.find_root().info_name} auth login`"
+                f"No credentials found, please run `fulcra auth login`"
             )
-        return f(ctx, *args, **kwargs)
+        return f(fulcra_api, *args, **kwargs)
 
     return wrapper
 

--- a/fulcra_api/cli/utils.py
+++ b/fulcra_api/cli/utils.py
@@ -6,7 +6,11 @@ from functools import wraps
 import click
 import dateparser
 
+from ..core import FulcraAPI
 from ..credentials import FulcraCredentials
+
+# Create a pass decorator for FulcraAPI to enable type hints in subcommands
+pass_fulcra_api = click.make_pass_decorator(FulcraAPI)
 
 CONFIG_PATH = pathlib.Path.home() / ".config" / "fulcra"
 CREDS_FILE = pathlib.Path(CONFIG_PATH / "credentials.json")

--- a/fulcra_api/cli/utils.py
+++ b/fulcra_api/cli/utils.py
@@ -6,8 +6,8 @@ from functools import wraps
 import click
 import dateparser
 
-from ..core import FulcraAPI
-from ..credentials import FulcraCredentials
+from fulcra_api.core import FulcraAPI
+from fulcra_api.credentials import FulcraCredentials
 
 # Create a pass decorator for FulcraAPI to enable type hints in subcommands
 pass_fulcra_api = click.make_pass_decorator(FulcraAPI)


### PR DESCRIPTION
- Use `make_pass_decorator()`, to create `pass_fulcra_api` in `utils.py` module:
  - pass_fulcra_api = click.make_pass_decorator(FulcraAPI)
- Update all commands to use `@pass_fulcra_api` instead of `@click.pass_context`
- Replace `ctx` parameter with typed `fulcra_api` parameter in command methods

Example:
```python
@file.command("list", short_help="List files")
@click.argument("path", type=str, default="/")
@pass_fulcra_api
@requires_auth
  def file_list(fulcra_api: FulcraAPI, path: str):
    ...   
```