### PR TITLE
Resolve existing tags from 'tag create' command

### DIFF
--- a/fulcra_api/cli/tags.py
+++ b/fulcra_api/cli/tags.py
@@ -90,7 +90,7 @@ def get_tag(fulcra_api: FulcraAPI, name_or_id: str):
 @click.argument("names", nargs=-1)
 @pass_fulcra_api
 @requires_auth
-def tag_create(fulcra_api: FulcraAPI, names: Tuple[str, ...]):
+def tag_create(fulcra_api: FulcraAPI, names: tuple[str, ...]):
     """
     Create case-insensitive user-defined tags by name that can be used when creating and recording custom data types.
     """

--- a/fulcra_api/cli/tags.py
+++ b/fulcra_api/cli/tags.py
@@ -95,7 +95,7 @@ def tag_create(fulcra_api: FulcraAPI, names: Tuple[str, ...]):
     Create case-insensitive user-defined tags by name that can be used when creating and recording custom data types.
     """
 
-    created_tags = fulcra_api.create_tags([n for n in names])
+    created_tags = fulcra_api.create_tags(list(names))
     click.echo(json.dumps(created_tags))
 
 

--- a/fulcra_api/cli/tags.py
+++ b/fulcra_api/cli/tags.py
@@ -95,18 +95,7 @@ def tag_create(fulcra_api: FulcraAPI, names: Tuple[str, ...]):
     Create case-insensitive user-defined tags by name that can be used when creating and recording custom data types.
     """
 
-    created_tags = []
-
-    for name in names:
-        tag_name = name.lower()
-        try:
-            resp = fulcra_api.create_tag(tag_name)
-            created_tags.append(resp)
-        except HTTPError as exc:
-            if exc.status == 409:
-                continue
-            raise click.ClickException(f"Failed to create tag {tag_name}: {exc}")
-
+    created_tags = fulcra_api.create_tags([n for n in names])
     click.echo(json.dumps(created_tags))
 
 

--- a/fulcra_api/core.py
+++ b/fulcra_api/core.py
@@ -1854,7 +1854,7 @@ class FulcraAPI:
         resp = self.fulcra_v1_api("metric", "ScaleAnnotation", params)
         return json.loads(resp)
 
-    def tags(self) -> List[Dict]:
+    def tags(self) -> list[dict[str, str]]:
         """
         Retrieves user defined tags.
 
@@ -1868,7 +1868,7 @@ class FulcraAPI:
         resp = self.fulcra_api("/user/v1alpha1/tag")
         return json.loads(resp)
 
-    def get_tag_by_name(self, name: str) -> Dict:
+    def get_tag_by_name(self, name: str) -> dict[str, str]:
         """
         Retrieves a user defined tag by name.
 
@@ -1882,7 +1882,7 @@ class FulcraAPI:
         resp = self.fulcra_api(f"/user/v1alpha1/tag/name/{name}")
         return json.loads(resp)
 
-    def get_tag_by_id(self, tag_id: str) -> Dict:
+    def get_tag_by_id(self, tag_id: str) -> dict[str, str]:
         """
         Retrieves a user defined tag by ID.
 
@@ -1896,7 +1896,7 @@ class FulcraAPI:
         resp = self.fulcra_api(f"/user/v1alpha1/tag/id/{tag_id}")
         return json.loads(resp)
 
-    def create_tag(self, tag_name: str) -> List[Dict]:
+    def create_tag(self, tag_name: str) -> dict[str, str]:
         """
         Creates a user defined tag.
 
@@ -1912,7 +1912,7 @@ class FulcraAPI:
         )
         return json.loads(resp)
 
-    def create_tags(self, tag_names: List[str]) -> List[Dict]:
+    def create_tags(self, tag_names: list[str]) -> list[dict[str, str]]:
         """
         Creates a batch of user defined tags.
 
@@ -1926,7 +1926,7 @@ class FulcraAPI:
         """
 
         existing_tags = self.tags()
-        result = []
+        result: list[dict[str, str]] = []
         for tag_name in tag_names:
             try:
                 tag = next(t for t in existing_tags if t["name"] == tag_name)


### PR DESCRIPTION
The current behavior of the `tag create` command will not include information about tags that already exist. This PR resolves existing tags and will return tag info in the output for them:
- Replaces current `FulcraAPI` call in `tag create` command with `FulcraAPI.create_tags()`