### PR TITLE
Preseve session ID via the ID token

### DIFF
--- a/fulcra_api/oidc.py
+++ b/fulcra_api/oidc.py
@@ -159,7 +159,7 @@ class FulcraOIDCProvider:
             access_token=access_token,
             access_token_expiration=expires_in,
             refresh_token=refresh_token,
-            id_token=id_token,
+            id_token=id_token
         )
 
     def refresh_credentials(self, credentials: FulcraCredentials) -> FulcraCredentials:
@@ -167,6 +167,10 @@ class FulcraOIDCProvider:
         if credentials.refresh_token is None:
             raise Exception("No refresh token available to refresh credentials with")
 
-        payload = {"refresh_token": credentials.refresh_token, "scope": self.scope}
+        payload = {
+            "refresh_token": credentials.refresh_token,
+            "scope": self.scope,
+            "id_token": credentials.id_token,
+        }
 
         return self.get_token("refresh_token", payload)


### PR DESCRIPTION
Sends the ID token with the refresh request so it can be used to validate the authenticated `fulcra_session_id`, and attach it to the new access and ID tokens after refresh.

- Depends on https://github.com/fulcradynamics/fulcra-api-python/pull/44