### PR TITLE
File sharing commands

### DIFF
--- a/fulcra_api/cli/files.py
+++ b/fulcra_api/cli/files.py
@@ -25,9 +25,17 @@ def file():
     default=None,
     help="Fulcra user ID of which files to fetch.",
 )
+@click.option(
+    "--base-name",
+    type=str,
+    default=None,
+    help="Filter files and folders by base name.",
+)
 @pass_fulcra_api
 @requires_auth
-def file_list(fulcra_api: FulcraAPI, path: str, user_id: str | None):
+def file_list(
+    fulcra_api: FulcraAPI, path: str, user_id: str | None, base_name: str | None
+):
     """List uploaded files.
 
     PATH: Path to list files in [Default: /]
@@ -36,7 +44,9 @@ def file_list(fulcra_api: FulcraAPI, path: str, user_id: str | None):
     path = make_filepath(path)
 
     try:
-        results = fulcra_api.list_files(path, fulcra_userid=user_id)
+        results = fulcra_api.list_files(
+            path, fulcra_userid=user_id, base_name=base_name
+        )
     except HTTPError as exc:
         error_body = exc.read().decode("utf-8")
         raise click.ClickException(f"Failed to list files: {exc}\n{error_body}")

--- a/fulcra_api/cli/files.py
+++ b/fulcra_api/cli/files.py
@@ -74,9 +74,17 @@ def file_list(
     default=None,
     help="Fulcra user ID of which files to fetch.",
 )
+@click.option(
+    "--include-deleted",
+    is_flag=True,
+    default=False,
+    help="Include deleted versions of the file.",
+)
 @pass_fulcra_api
 @requires_auth
-def file_stat(fulcra_api: FulcraAPI, path: str, user_id: str | None):
+def file_stat(
+    fulcra_api: FulcraAPI, path: str, user_id: str | None, include_deleted: bool
+):
     """Returns information about an uploaded file, including size, date uploaded, and all previously uploaded versions of the file.
 
     PATH: Full path of the file.
@@ -85,7 +93,12 @@ def file_stat(fulcra_api: FulcraAPI, path: str, user_id: str | None):
     path = make_filepath(path)
 
     try:
-        f = fulcra_api.resolve_filepath(path, all_versions=True, fulcra_userid=user_id)
+        f = fulcra_api.resolve_filepath(
+            path,
+            all_versions=True,
+            fulcra_userid=user_id,
+            include_deleted=include_deleted,
+        )
     except HTTPError as exc:
         error_body = exc.read().decode("utf-8")
         raise click.ClickException(f"Failed to stat file: {exc}\n{error_body}")
@@ -96,6 +109,11 @@ def file_stat(fulcra_api: FulcraAPI, path: str, user_id: str | None):
 
     click.echo(
         f"{make_filepath(latest_version['path'], latest_version['name'])} ({latest_version['size']} bytes)"
+        + (
+            f" (X deleted {latest_version['deleted_at']})"
+            if latest_version["state"] == "deleted"
+            else ""
+        )
     )
     click.echo(f"Uploaded: {latest_version['uploaded_at']}")
     click.echo(f"Version: {latest_version['id']}")
@@ -103,6 +121,11 @@ def file_stat(fulcra_api: FulcraAPI, path: str, user_id: str | None):
     for file_version in f[1:]:
         click.echo(
             f"- {file_version['id']} {file_version['uploaded_at']} ({file_version['size']} bytes)"
+            + (
+                f" (X deleted {file_version['deleted_at']})"
+                if file_version["state"] == "deleted"
+                else ""
+            )
         )
 
 

--- a/fulcra_api/cli/files.py
+++ b/fulcra_api/cli/files.py
@@ -140,10 +140,20 @@ def file_stat(
     default=None,
     help="Fulcra user ID of which files to fetch.",
 )
+@click.option(
+    "--version",
+    type=str,
+    default=None,
+    help="File version to download (defaults to latest).",
+)
 @pass_fulcra_api
 @requires_auth
 def file_download(
-    fulcra_api: FulcraAPI, remote_file: str, local_file: str | None, user_id: str | None
+    fulcra_api: FulcraAPI,
+    remote_file: str,
+    local_file: str | None,
+    user_id: str | None,
+    version: str | None,
 ):
     """Download a file.
 
@@ -157,7 +167,14 @@ def file_download(
     remote_file = make_filepath(remote_file)
 
     try:
-        f = fulcra_api.resolve_filepath(remote_file, fulcra_userid=user_id)
+        if version is not None:
+            f = [
+                fulcra_api.get_file_by_version(
+                    version_id=version, fulcra_userid=user_id
+                )
+            ]
+        else:
+            f = fulcra_api.resolve_filepath(remote_file, fulcra_userid=user_id)
         resp = fulcra_api.download_file(f[0].get("id"), fulcra_userid=user_id)
     except HTTPError as exc:
         error_body = exc.read().decode("utf-8")
@@ -265,7 +282,7 @@ def file_restore(fulcra_api: FulcraAPI, version_id):
             raise click.ClickException(f"File version {version_id} not found")
         else:
             error_body = exc.read().decode("utf-8")
-            raise click.ClickException(f"Failed to download file: {exc}\n{error_body}")
+            raise click.ClickException(f"Failed to restore file: {exc}\n{error_body}")
 
     full_file_name = make_filepath(file_version["path"], file_version["name"])
 

--- a/fulcra_api/cli/files.py
+++ b/fulcra_api/cli/files.py
@@ -54,9 +54,15 @@ def file_list(fulcra_api: FulcraAPI, path: str, user_id: str | None):
 
 @file.command("stat", short_help="Get information about a file")
 @click.argument("path", type=str)
+@click.option(
+    "--user-id",
+    type=str,
+    default=None,
+    help="Fulcra user ID of which files to fetch.",
+)
 @pass_fulcra_api
 @requires_auth
-def file_stat(fulcra_api: FulcraAPI, path: str):
+def file_stat(fulcra_api: FulcraAPI, path: str, user_id: str | None):
     """Returns information about an uploaded file, including size, date uploaded, and all previously uploaded versions of the file.
 
     PATH: Full path of the file.
@@ -65,7 +71,7 @@ def file_stat(fulcra_api: FulcraAPI, path: str):
     path = make_filepath(path)
 
     try:
-        f = fulcra_api.resolve_filepath(path, all_versions=True)
+        f = fulcra_api.resolve_filepath(path, all_versions=True, fulcra_userid=user_id)
     except Exception as exc:
         raise click.ClickException(exc)
 
@@ -111,7 +117,7 @@ def file_download(
     remote_file = make_filepath(remote_file)
 
     try:
-        f = fulcra_api.resolve_filepath(remote_file)
+        f = fulcra_api.resolve_filepath(remote_file, fulcra_userid=user_id)
     except Exception as exc:
         raise click.ClickException(exc)
 

--- a/fulcra_api/cli/files.py
+++ b/fulcra_api/cli/files.py
@@ -88,10 +88,16 @@ def file_stat(fulcra_api: FulcraAPI, path: str):
 @click.argument(
     "local_file", type=click.Path(allow_dash=True), required=False, default=None
 )
+@click.option(
+    "--user-id",
+    type=str,
+    default=None,
+    help="Fulcra user ID of which files to fetch.",
+)
 @pass_fulcra_api
 @requires_auth
 def file_download(
-    fulcra_api: FulcraAPI, remote_file: str, local_file: str | None = None
+    fulcra_api: FulcraAPI, remote_file: str, local_file: str | None, user_id: str | None
 ):
     """Download a file.
 
@@ -109,7 +115,7 @@ def file_download(
     except Exception as exc:
         raise click.ClickException(exc)
 
-    resp = fulcra_api.download_file(f[0].get("id"))
+    resp = fulcra_api.download_file(f[0].get("id"), fulcra_userid=user_id)
     remote_name = pathlib.PurePath(f[0].get("name")).name
 
     if local_file == "-":  # "-" → stdout

--- a/fulcra_api/cli/files.py
+++ b/fulcra_api/cli/files.py
@@ -69,15 +69,19 @@ def file_list(
         for d in results.get("folders", []):
             click.echo(f"{d}/")
 
-    # Prefer the live version of each file
+    # Prefer the live and latest version of each file
     files = {}
     for f in results.get("files", []):
         name = f.get("name")
         if name not in files:
             files[name] = f
             continue
-        if f.get("state") == "uploaded":
+        if f.get("state") == "uploaded" and files[name].get("state") != "uploaded":
             files[name] = f
+            continue
+        if f.get("uploaded_at", "") > files[name].get("uploaded_at", ""):
+            files[name] = f
+            continue
 
     filtered_files = sorted(files.values(), key=lambda f: f.get("name"))
     for f in filtered_files:

--- a/fulcra_api/cli/files.py
+++ b/fulcra_api/cli/files.py
@@ -19,9 +19,15 @@ def file():
 
 @file.command("list", short_help="List files")
 @click.argument("path", type=str, default="/")
+@click.option(
+    "--user-id",
+    type=str,
+    default=None,
+    help="Fulcra user ID of which files to fetch.",
+)
 @pass_fulcra_api
 @requires_auth
-def file_list(fulcra_api: FulcraAPI, path: str):
+def file_list(fulcra_api: FulcraAPI, path: str, user_id: str | None):
     """List uploaded files.
 
     PATH: Path to list files in [Default: /]
@@ -29,7 +35,7 @@ def file_list(fulcra_api: FulcraAPI, path: str):
 
     path = make_filepath(path)
 
-    results = fulcra_api.list_files(path)
+    results = fulcra_api.list_files(path, fulcra_userid=user_id)
 
     if results.get("folders") is not None:
         for d in results.get("folders", []):

--- a/fulcra_api/cli/files.py
+++ b/fulcra_api/cli/files.py
@@ -110,7 +110,7 @@ def file_stat(
     click.echo(
         f"{make_filepath(latest_version['path'], latest_version['name'])} ({latest_version['size']} bytes)"
         + (
-            f" (X deleted {latest_version['deleted_at']})"
+            f" (deleted {latest_version['deleted_at']})"
             if latest_version["state"] == "deleted"
             else ""
         )
@@ -122,7 +122,7 @@ def file_stat(
         click.echo(
             f"- {file_version['id']} {file_version['uploaded_at']} ({file_version['size']} bytes)"
             + (
-                f" (X deleted {file_version['deleted_at']})"
+                f" (deleted {file_version['deleted_at']})"
                 if file_version["state"] == "deleted"
                 else ""
             )

--- a/fulcra_api/cli/files.py
+++ b/fulcra_api/cli/files.py
@@ -35,7 +35,11 @@ def file_list(fulcra_api: FulcraAPI, path: str, user_id: str | None):
 
     path = make_filepath(path)
 
-    results = fulcra_api.list_files(path, fulcra_userid=user_id)
+    try:
+        results = fulcra_api.list_files(path, fulcra_userid=user_id)
+    except HTTPError as exc:
+        error_body = exc.read().decode("utf-8")
+        raise click.ClickException(f"Failed to list files: {exc}\n{error_body}")
 
     if results.get("folders") is not None:
         for d in results.get("folders", []):
@@ -72,6 +76,9 @@ def file_stat(fulcra_api: FulcraAPI, path: str, user_id: str | None):
 
     try:
         f = fulcra_api.resolve_filepath(path, all_versions=True, fulcra_userid=user_id)
+    except HTTPError as exc:
+        error_body = exc.read().decode("utf-8")
+        raise click.ClickException(f"Failed to stat file: {exc}\n{error_body}")
     except Exception as exc:
         raise click.ClickException(exc)
 
@@ -118,10 +125,13 @@ def file_download(
 
     try:
         f = fulcra_api.resolve_filepath(remote_file, fulcra_userid=user_id)
+        resp = fulcra_api.download_file(f[0].get("id"), fulcra_userid=user_id)
+    except HTTPError as exc:
+        error_body = exc.read().decode("utf-8")
+        raise click.ClickException(f"Failed to download file: {exc}\n{error_body}")
     except Exception as exc:
         raise click.ClickException(exc)
 
-    resp = fulcra_api.download_file(f[0].get("id"), fulcra_userid=user_id)
     remote_name = pathlib.PurePath(f[0].get("name")).name
 
     if local_file == "-":  # "-" → stdout
@@ -175,7 +185,8 @@ def file_upload(fulcra_api: FulcraAPI, local_file: click.File, remote_file: str)
         new_file = fulcra_api.upload_file(local_file, file_type, file_size, path)
         full_path = make_filepath(new_file["file"]["path"], new_file["file"]["name"])
     except HTTPError as exc:
-        raise click.ClickException(exc.fp.read())
+        error_body = exc.read().decode("utf-8")
+        raise click.ClickException(f"Failed to upload file: {exc}\n{error_body}")
 
     click.echo(f"⬆️ {local_file.name} -> fulcra:{full_path}")
 
@@ -193,6 +204,9 @@ def file_delete(fulcra_api: FulcraAPI, path):
 
     try:
         f = fulcra_api.resolve_filepath(path)
+    except HTTPError as exc:
+        error_body = exc.read().decode("utf-8")
+        raise click.ClickException(f"Failed to delete file: {exc}\n{error_body}")
     except Exception as exc:
         raise click.ClickException(exc)
 
@@ -217,7 +231,8 @@ def file_restore(fulcra_api: FulcraAPI, version_id):
         if exc.status == 404:
             raise click.ClickException(f"File version {version_id} not found")
         else:
-            raise click.ClickException(exc)
+            error_body = exc.read().decode("utf-8")
+            raise click.ClickException(f"Failed to download file: {exc}\n{error_body}")
 
     full_file_name = make_filepath(file_version["path"], file_version["name"])
 

--- a/fulcra_api/cli/files.py
+++ b/fulcra_api/cli/files.py
@@ -31,10 +31,20 @@ def file():
     default=None,
     help="Filter files and folders by base name.",
 )
+@click.option(
+    "--include-deleted",
+    is_flag=True,
+    default=False,
+    help="Include deleted files.",
+)
 @pass_fulcra_api
 @requires_auth
 def file_list(
-    fulcra_api: FulcraAPI, path: str, user_id: str | None, base_name: str | None
+    fulcra_api: FulcraAPI,
+    path: str,
+    user_id: str | None,
+    base_name: str | None,
+    include_deleted: bool,
 ):
     """List uploaded files.
 
@@ -44,8 +54,12 @@ def file_list(
     path = make_filepath(path)
 
     try:
+        if include_deleted:
+            state = "uploaded,deleted"
+        else:
+            state = "uploaded"
         results = fulcra_api.list_files(
-            path, fulcra_userid=user_id, base_name=base_name
+            path, fulcra_userid=user_id, base_name=base_name, state=state
         )
     except HTTPError as exc:
         error_body = exc.read().decode("utf-8")
@@ -55,14 +69,28 @@ def file_list(
         for d in results.get("folders", []):
             click.echo(f"{d}/")
 
+    # Prefer the live version of each file
+    files = {}
     for f in results.get("files", []):
+        name = f.get("name")
+        if name not in files:
+            files[name] = f
+            continue
+        if f.get("state") == "uploaded":
+            files[name] = f
+
+    filtered_files = sorted(files.values(), key=lambda f: f.get("name"))
+    for f in filtered_files:
         size, unit = human_size(f.get("size"))
         try:
             dt = datetime.fromisoformat(f.get("uploaded_at"))
         except TypeError:
             dt = datetime(1970, 1, 1, tzinfo=timezone.utc)
+        status = (
+            f" (deleted {f.get('deleted_at')})" if f.get("state") == "deleted" else ""
+        )
         click.echo(
-            f"{str(size) + unit:7} {dt.strftime('%Y-%m-%d %I:%M%p %Z')}  {f.get('name')}"
+            f"{str(size) + unit:7} {dt.strftime('%Y-%m-%d %I:%M%p %Z')}  {f.get('name')}{status}"
         )
 
 

--- a/fulcra_api/cli/share.py
+++ b/fulcra_api/cli/share.py
@@ -64,19 +64,19 @@ def list_incoming(fulcra_api: FulcraAPI):
     "--data-type",
     "data_types",
     multiple=True,
-    help="Data type ID to share (can be specified multiple times)",
+    help="Data type ID to share. Can be specified multiple times.",
 )
 @click.option(
     "--file",
     "files",
     multiple=True,
-    help='File to share (can be specified multiple times). Suffix with "/" to share a prefix. Shares the live version only.',
+    help='File or directory to share the latest version of. Can be specified multiple times. ',
 )
 @click.option(
     "--file-history",
     "file_histories",
     multiple=True,
-    help='File history to share, including live version (can be specified multiple times). Suffix with "/" to share a prefix.',
+    help='File or directory to share, including complete version history. Can be specified multiple times.',
 )
 @click.option(
     "--user-id",
@@ -125,6 +125,10 @@ def create(
     \b
     Share all data types:
     fulcra share create --name "Full Access" --share-all --user-id <USER-UUID>
+
+    \b
+    Share all files in the /collaboration/context/ directory:
+    fulcra share create --name "Context files" --file /collaboration/context/
     """
     # Validate data types against catalog
     share_types = list(data_types)

--- a/fulcra_api/cli/share.py
+++ b/fulcra_api/cli/share.py
@@ -216,6 +216,24 @@ def leave(fulcra_api: FulcraAPI, share_id: str):
     help="Replace all data types with this list (can be specified multiple times)",
 )
 @click.option(
+    "--add-file",
+    "add_files",
+    multiple=True,
+    help="Add a file prefix to the share (can be specified multiple times)",
+)
+@click.option(
+    "--remove-file",
+    "remove_files",
+    multiple=True,
+    help="Remove file prefix from the share (can be specified multiple times)",
+)
+@click.option(
+    "--set-files",
+    "set_files",
+    multiple=True,
+    help="Replace all file prefixes with this list (can be specified multiple times)",
+)
+@click.option(
     "--add-user-id",
     "add_user_ids",
     multiple=True,
@@ -284,6 +302,9 @@ def update(
     add_data_types,
     remove_data_types,
     set_data_types,
+    add_files,
+    remove_files,
+    set_files,
     add_user_ids,
     remove_user_ids,
     set_user_ids,
@@ -341,6 +362,9 @@ def update(
             add_data_types,
             remove_data_types,
             set_data_types,
+            add_files,
+            remove_files,
+            set_files,
             add_user_ids,
             remove_user_ids,
             set_user_ids,
@@ -359,6 +383,12 @@ def update(
     if set_data_types and (add_data_types or remove_data_types):
         raise click.UsageError(
             "--set-data-type cannot be used with --add-data-type or --remove-data-type"
+        )
+
+    # Validate mutual exclusivity for file prefixes
+    if set_files and (add_files or remove_files):
+        raise click.UsageError(
+            "--set-file cannot be used with --add-file or --remove-file"
         )
 
     # Validate mutual exclusivity for user IDs

--- a/fulcra_api/cli/share.py
+++ b/fulcra_api/cli/share.py
@@ -414,6 +414,19 @@ def update(
         if not current_share:
             raise click.ClickException(f"Share {share_id} not found")
 
+        file_type_prefixes = ("file:", "filehistory:")
+        current_catalog_types: list[str] = [
+            t
+            for t in current_share.get("fulcra_data_types", [])
+            if not t.startswith(file_type_prefixes)
+        ]
+
+        current_file_types: list[str] = [
+            t
+            for t in current_share.get("fulcra_data_types", [])
+            if t.startswith(file_type_prefixes)
+        ]
+
         # Initialize update arguments with all current values
         update_kwargs: Dict[str, Any] = {
             "datashare_id": share_id,

--- a/fulcra_api/cli/share.py
+++ b/fulcra_api/cli/share.py
@@ -70,13 +70,13 @@ def list_incoming(fulcra_api: FulcraAPI):
     "--file",
     "files",
     multiple=True,
-    help="File to share (can be specified multiple times). Suffix with / to share a directory's contents. Shares the live version only.",
+    help='File to share (can be specified multiple times). Suffix with "/" to share a prefix. Shares the live version only.',
 )
 @click.option(
     "--file-history",
     "file_histories",
     multiple=True,
-    help="File history to share, including live version (can be specified multiple times). Suffix with / to share a directory's contents.",
+    help='File history to share, including live version (can be specified multiple times). Suffix with "/" to share a prefix.',
 )
 @click.option(
     "--user-id",
@@ -232,37 +232,37 @@ def leave(fulcra_api: FulcraAPI, share_id: str):
     "--add-file",
     "add_files",
     multiple=True,
-    help="Add a file to the share (can be specified multiple times). Suffix with / to share a directory's contents. Shares the live version only.",
+    help='Add a file to the share (can be specified multiple times). Suffix with "/" to share a prefix. Shares the live version only.',
 )
 @click.option(
     "--remove-file",
     "remove_files",
     multiple=True,
-    help="Remove a live version file or directory from the share (can be specified multiple times)",
+    help="Remove a live version file or prefix from the share (can be specified multiple times)",
 )
 @click.option(
     "--set-file",
     "set_files",
     multiple=True,
-    help="Replace all live version file and directory shares with this list (can be specified multiple times)",
+    help="Replace all live version file and prefix shares with this list (can be specified multiple times)",
 )
 @click.option(
     "--add-file-history",
     "add_file_histories",
     multiple=True,
-    help="Add a file history to the share, including live version (can be specified multiple times). Suffix with / to share a directory's contents.",
+    help='Add a file history to the share, including live version (can be specified multiple times). Suffix with "/" to share a prefix.',
 )
 @click.option(
     "--remove-file-history",
     "remove_file_histories",
     multiple=True,
-    help="Remove a file or directory history from the share (can be specified multiple times)",
+    help="Remove a file or prefix history from the share (can be specified multiple times)",
 )
 @click.option(
     "--set-file-history",
     "set_file_histories",
     multiple=True,
-    help="Replace all file and directory history shares with this list (can be specified multiple times)",
+    help="Replace all file and prefix history shares with this list (can be specified multiple times)",
 )
 @click.option(
     "--add-user-id",

--- a/fulcra_api/cli/share.py
+++ b/fulcra_api/cli/share.py
@@ -218,7 +218,7 @@ def leave(fulcra_api: FulcraAPI, share_id: str):
     "--add-data-type",
     "add_data_types",
     multiple=True,
-    help="Add a data type to the share (can be specified multiple times)",
+    help="Add a data type to the share. Can be specified multiple times",
 )
 @click.option(
     "--remove-data-type",

--- a/fulcra_api/cli/share.py
+++ b/fulcra_api/cli/share.py
@@ -495,7 +495,7 @@ def update(
 
         updated_types = current_share.get("fulcra_data_types", [])
 
-        # Hancle clear
+        # Handle clear
         if clear:
             updated_types = []
             update_kwargs["share_all_data"] = False

--- a/fulcra_api/cli/share.py
+++ b/fulcra_api/cli/share.py
@@ -228,10 +228,28 @@ def leave(fulcra_api: FulcraAPI, share_id: str):
     help="Remove file prefix from the share (can be specified multiple times)",
 )
 @click.option(
-    "--set-files",
+    "--set-file",
     "set_files",
     multiple=True,
     help="Replace all file prefixes with this list (can be specified multiple times)",
+)
+@click.option(
+    "--add-file-history",
+    "add_file_histories",
+    multiple=True,
+    help="Add a file historyprefix to the share (can be specified multiple times)",
+)
+@click.option(
+    "--remove-file-history",
+    "remove_file_histories",
+    multiple=True,
+    help="Remove file history prefix from the share (can be specified multiple times)",
+)
+@click.option(
+    "--set-file-history",
+    "set_file_histories",
+    multiple=True,
+    help="Replace all file history prefixes with this list (can be specified multiple times)",
 )
 @click.option(
     "--add-user-id",
@@ -305,6 +323,9 @@ def update(
     add_files,
     remove_files,
     set_files,
+    add_file_histories,
+    remove_file_histories,
+    set_file_histories,
     add_user_ids,
     remove_user_ids,
     set_user_ids,
@@ -391,6 +412,11 @@ def update(
             "--set-file cannot be used with --add-file or --remove-file"
         )
 
+    if set_file_histories and (add_file_histories or remove_file_histories):
+        raise click.UsageError(
+            "--set-file-history cannot be used with --add-file-history or --remove-file-history"
+        )
+
     # Validate mutual exclusivity for user IDs
     if set_user_ids and (add_user_ids or remove_user_ids):
         raise click.UsageError(
@@ -413,19 +439,6 @@ def update(
         )
         if not current_share:
             raise click.ClickException(f"Share {share_id} not found")
-
-        file_type_prefixes = ("file:", "filehistory:")
-        current_catalog_types: list[str] = [
-            t
-            for t in current_share.get("fulcra_data_types", [])
-            if not t.startswith(file_type_prefixes)
-        ]
-
-        current_file_types: list[str] = [
-            t
-            for t in current_share.get("fulcra_data_types", [])
-            if t.startswith(file_type_prefixes)
-        ]
 
         # Initialize update arguments with all current values
         update_kwargs: Dict[str, Any] = {
@@ -451,24 +464,41 @@ def update(
             update_kwargs["datashare_name"] = name
 
         # Handle data types
+        updated_types = current_share.get("fulcra_data_types", [])
         if set_data_types:
-            update_kwargs["fulcra_data_types"] = sorted(set_data_types)
-        elif add_data_types or remove_data_types:
-            current_data_types = set(update_kwargs["fulcra_data_types"] or [])
+            updated_types = sorted(set_data_types)
 
-            for dt in add_data_types:
-                if dt in current_data_types:
-                    click.echo(f"Warning: {dt} already in share, skipping", err=True)
-                else:
-                    current_data_types.add(dt)
+        if set_files:
+            updated_types = [t for t in updated_types if not t.startswith("file:")] + [
+                f"file:{f}" for f in sorted(set_files)
+            ]
+        if set_file_histories:
+            updated_types = [
+                t for t in updated_types if not t.startswith("filehistory:")
+            ] + [f"filehistory:{f}" for f in sorted(set_file_histories)]
 
-            for dt in remove_data_types:
-                if dt not in current_data_types:
-                    click.echo(f"Warning: {dt} not in share, skipping", err=True)
-                else:
-                    current_data_types.remove(dt)
+        add_types = add_data_types or []
+        if add_files:
+            add_types += [f"file:{f}" for f in sorted(add_files)]
+        if add_file_histories:
+            add_types += [f"filehistory:{f}" for f in sorted(add_file_histories)]
+        remove_types = remove_data_types or []
+        if remove_files:
+            remove_types += [f"file:{f}" for f in sorted(remove_files)]
+        if remove_file_histories:
+            remove_types += [f"filehistory:{f}" for f in sorted(remove_file_histories)]
 
-            update_kwargs["fulcra_data_types"] = sorted(current_data_types)
+        for add_type in add_types:
+            if dt in updated_types:
+                click.echo(f"Warning: {add_type} already in share, skipping", err=True)
+            else:
+                updated_types.add(add_type)
+
+        for remove_type in remove_types:
+            if dt in updated_types:
+                click.echo(f"Warning: {remove_type} not in share, skipping", err=True)
+            else:
+                updated_types.remove(remove_type)
 
         # Handle user IDs
         if set_user_ids:

--- a/fulcra_api/cli/share.py
+++ b/fulcra_api/cli/share.py
@@ -64,8 +64,19 @@ def list_incoming(fulcra_api: FulcraAPI):
     "--data-type",
     "data_types",
     multiple=True,
-    required=True,
     help="Data type ID to share (can be specified multiple times)",
+)
+@click.option(
+    "--file",
+    "files",
+    multiple=True,
+    help="File prefix to share (can be specified multiple times)",
+)
+@click.option(
+    "--file-history",
+    "file_histories",
+    multiple=True,
+    help="File history prefix to share (can be specified multiple times)",
 )
 @click.option(
     "--user-id",
@@ -85,7 +96,15 @@ def list_incoming(fulcra_api: FulcraAPI):
 @pass_fulcra_api
 @requires_auth
 def create(
-    fulcra_api: FulcraAPI, name, data_types, user_ids, start_time, end_time, share_all
+    fulcra_api: FulcraAPI,
+    name,
+    data_types,
+    files,
+    file_histories,
+    user_ids,
+    start_time,
+    end_time,
+    share_all,
 ):
     """
     Create a new share to share your data with other users.
@@ -123,6 +142,13 @@ def create(
         error_body = exc.read().decode("utf-8")
         raise click.ClickException(f"Failed to fetch catalog: {exc}\n{error_body}")
 
+    share_types = data_types
+    for file in files:
+        share_types.append(f"file:{file}")
+    for file_history in file_histories:
+        share_types.append(f"filehistory:{file_history}")
+    share_types = sorted(set(share_types))
+
     # Parse time arguments if provided
     parsed_start_time = None
     parsed_end_time = None
@@ -146,7 +172,7 @@ def create(
     try:
         result = fulcra_api.create_datashare(
             datashare_name=name,
-            fulcra_data_types=sorted(data_types),
+            fulcra_data_types=share_types,
             allowed_user_ids=sorted(user_ids),
             share_all_data=share_all,
             time_start=parsed_start_time,

--- a/fulcra_api/cli/share.py
+++ b/fulcra_api/cli/share.py
@@ -236,37 +236,37 @@ def leave(fulcra_api: FulcraAPI, share_id: str):
     "--add-file",
     "add_files",
     multiple=True,
-    help='Add a file to the share (can be specified multiple times). Suffix with "/" to share a prefix. Shares the live version only.',
+    help="Add a file or directory to share the latest version of. Can be specified multiple times.",
 )
 @click.option(
     "--remove-file",
     "remove_files",
     multiple=True,
-    help="Remove a live version file or prefix from the share (can be specified multiple times)",
+    help="Remove a file or directory sharing the latest version. Can be specified multiple times.",
 )
 @click.option(
     "--set-file",
     "set_files",
     multiple=True,
-    help="Replace all live version file and prefix shares with this list (can be specified multiple times)",
+    help="Replace all files or directories sharing the latest version with this list. Can be specified multiple times.",
 )
 @click.option(
     "--add-file-history",
     "add_file_histories",
     multiple=True,
-    help='Add a file history to the share, including live version (can be specified multiple times). Suffix with "/" to share a prefix.',
+    help="Add a file or directory to share, including complete version history. Can be specified multiple times.",
 )
 @click.option(
     "--remove-file-history",
     "remove_file_histories",
     multiple=True,
-    help="Remove a file or prefix history from the share (can be specified multiple times)",
+    help="Remove a file or directory sharing complete version history. Can be specified multiple times.",
 )
 @click.option(
     "--set-file-history",
     "set_file_histories",
     multiple=True,
-    help="Replace all file and prefix history shares with this list (can be specified multiple times)",
+    help="Replace all files or directories sharing complete version history with this list. Can be specified multiple times.",
 )
 @click.option(
     "--add-user-id",

--- a/fulcra_api/cli/share.py
+++ b/fulcra_api/cli/share.py
@@ -127,7 +127,7 @@ def create(
     fulcra share create --name "Full Access" --share-all --user-id <USER-UUID>
     """
     # Validate data types against catalog
-    share_types = data_types
+    share_types = list(data_types)
     for file in files:
         share_types.append(file_share_type(prefix=file, history=False))
     for file_history in file_histories:
@@ -331,6 +331,13 @@ def leave(fulcra_api: FulcraAPI, share_id: str):
     default=False,
     help="Skip data type validation",
 )
+@click.option(
+    "--clear",
+    "clear",
+    is_flag=True,
+    default=False,
+    help="Remove all shared data and files from the share, then add any specified by other options",
+)
 @pass_fulcra_api
 @requires_auth
 def update(
@@ -355,6 +362,7 @@ def update(
     end_time_value: str | None,
     no_end_time: bool,
     no_validate: bool,
+    clear: bool,
 ):
     """
     Update an existing share by modifying data types, users, or settings.
@@ -415,6 +423,7 @@ def update(
             no_start_time,
             end_time_value,
             no_end_time,
+            clear,
         ]
     )
 
@@ -484,8 +493,14 @@ def update(
         if name:
             update_kwargs["datashare_name"] = name
 
-        # Handle data types
         updated_types = current_share.get("fulcra_data_types", [])
+
+        # Hancle clear
+        if clear:
+            updated_types = []
+            update_kwargs["share_all_data"] = False
+
+        # Handle data types
         if set_data_types:
             updated_types = set_data_types
 
@@ -519,18 +534,20 @@ def update(
             if add_type in updated_types:
                 click.echo(f"Warning: {add_type} already in share, skipping", err=True)
             else:
-                updated_types.add(add_type)
+                updated_types.append(add_type)
 
         for remove_type in remove_types:
-            if remove_type in updated_types:
+            if remove_type not in updated_types:
                 click.echo(f"Warning: {remove_type} not in share, skipping", err=True)
             else:
-                updated_types.remove(remove_type)
+                updated_types = [t for t in updated_types if t != remove_type]
 
         if not no_validate:
             updated_types = valid_share_types(
                 fulcra_api=fulcra_api, share_types=updated_types
             )
+
+        update_kwargs["fulcra_data_types"] = updated_types
 
         # Handle user IDs
         if set_user_ids:

--- a/fulcra_api/cli/share.py
+++ b/fulcra_api/cli/share.py
@@ -7,7 +7,7 @@ import click
 
 from fulcra_api.core import FulcraAPI
 
-from .utils import pass_fulcra_api, requires_auth
+from .utils import file_share_type, pass_fulcra_api, requires_auth, valid_share_types
 
 
 @click.group(help="Data sharing management sub-commands")
@@ -93,18 +93,25 @@ def list_incoming(fulcra_api: FulcraAPI):
     default=False,
     help="Share all data types",
 )
+@click.option(
+    "--no-validate",
+    is_flag=True,
+    default=False,
+    help="Skip data type validation",
+)
 @pass_fulcra_api
 @requires_auth
 def create(
     fulcra_api: FulcraAPI,
-    name,
-    data_types,
-    files,
-    file_histories,
-    user_ids,
-    start_time,
-    end_time,
-    share_all,
+    name: str,
+    data_types: list[str],
+    files: list[str],
+    file_histories: list[str],
+    user_ids: list[str],
+    start_time: str | None,
+    end_time: str | None,
+    share_all: bool,
+    no_validate: bool,
 ):
     """
     Create a new share to share your data with other users.
@@ -120,34 +127,14 @@ def create(
     fulcra share create --name "Full Access" --share-all --user-id <USER-UUID>
     """
     # Validate data types against catalog
-    try:
-        catalog = fulcra_api.v1_catalog()
-        valid_data_type_ids = {item["id"] for item in catalog}
-
-        # TEMPORARY: Allow "calendars" and "calendar_events" even though they're not
-        # in the v1 catalog yet. Remove this special case once they're added to the catalog.
-        temporary_allowed_types = {"calendars", "calendar_events"}
-
-        invalid_types = [
-            dt
-            for dt in data_types
-            if dt not in valid_data_type_ids and dt not in temporary_allowed_types
-        ]
-        if invalid_types:
-            raise click.ClickException(
-                f"Invalid data type(s): {', '.join(invalid_types)}. "
-                f"Use 'fulcra catalog' to see valid data types."
-            )
-    except HTTPError as exc:
-        error_body = exc.read().decode("utf-8")
-        raise click.ClickException(f"Failed to fetch catalog: {exc}\n{error_body}")
-
     share_types = data_types
     for file in files:
-        share_types.append(f"file:{file}")
+        share_types.append(file_share_type(prefix=file, history=False))
     for file_history in file_histories:
-        share_types.append(f"filehistory:{file_history}")
-    share_types = sorted(set(share_types))
+        share_types.append(file_share_type(prefix=file_history, history=True))
+
+    if not no_validate:
+        share_types = valid_share_types(fulcra_api=fulcra_api, share_types=share_types)
 
     # Parse time arguments if provided
     parsed_start_time = None
@@ -337,29 +324,37 @@ def leave(fulcra_api: FulcraAPI, share_id: str):
     default=False,
     help="Remove end time (make share open-ended at end)",
 )
+@click.option(
+    "--no-validate",
+    "no_validate",
+    is_flag=True,
+    default=False,
+    help="Skip data type validation",
+)
 @pass_fulcra_api
 @requires_auth
 def update(
     fulcra_api: FulcraAPI,
     share_id: str,
-    name,
-    add_data_types,
-    remove_data_types,
-    set_data_types,
-    add_files,
-    remove_files,
-    set_files,
-    add_file_histories,
-    remove_file_histories,
-    set_file_histories,
-    add_user_ids,
-    remove_user_ids,
-    set_user_ids,
-    share_all_data,
-    start_time_value,
-    no_start_time,
-    end_time_value,
-    no_end_time,
+    name: str | None,
+    add_data_types: list[str],
+    remove_data_types: list[str],
+    set_data_types: list[str],
+    add_files: list[str],
+    remove_files: list[str],
+    set_files: list[str],
+    add_file_histories: list[str],
+    remove_file_histories: list[str],
+    set_file_histories: list[str],
+    add_user_ids: list[str],
+    remove_user_ids: list[str],
+    set_user_ids: list[str],
+    share_all_data: bool | None,
+    start_time_value: str | None,
+    no_start_time: bool,
+    end_time_value: str | None,
+    no_end_time: bool,
+    no_validate: bool,
 ):
     """
     Update an existing share by modifying data types, users, or settings.
@@ -492,39 +487,50 @@ def update(
         # Handle data types
         updated_types = current_share.get("fulcra_data_types", [])
         if set_data_types:
-            updated_types = sorted(set_data_types)
+            updated_types = set_data_types
 
         if set_files:
             updated_types = [t for t in updated_types if not t.startswith("file:")] + [
-                f"file:{f}" for f in sorted(set_files)
+                file_share_type(prefix=f, history=False) for f in set_files
             ]
         if set_file_histories:
             updated_types = [
                 t for t in updated_types if not t.startswith("filehistory:")
-            ] + [f"filehistory:{f}" for f in sorted(set_file_histories)]
+            ] + [file_share_type(prefix=f, history=True) for f in set_file_histories]
 
         add_types = add_data_types or []
         if add_files:
-            add_types += [f"file:{f}" for f in sorted(add_files)]
+            add_types += [file_share_type(prefix=f, history=False) for f in add_files]
         if add_file_histories:
-            add_types += [f"filehistory:{f}" for f in sorted(add_file_histories)]
+            add_types += [
+                file_share_type(prefix=f, history=True) for f in add_file_histories
+            ]
         remove_types = remove_data_types or []
         if remove_files:
-            remove_types += [f"file:{f}" for f in sorted(remove_files)]
+            remove_types += [
+                file_share_type(prefix=f, history=False) for f in remove_files
+            ]
         if remove_file_histories:
-            remove_types += [f"filehistory:{f}" for f in sorted(remove_file_histories)]
+            remove_types += [
+                file_share_type(prefix=f, history=True) for f in remove_file_histories
+            ]
 
         for add_type in add_types:
-            if dt in updated_types:
+            if add_type in updated_types:
                 click.echo(f"Warning: {add_type} already in share, skipping", err=True)
             else:
                 updated_types.add(add_type)
 
         for remove_type in remove_types:
-            if dt in updated_types:
+            if remove_type in updated_types:
                 click.echo(f"Warning: {remove_type} not in share, skipping", err=True)
             else:
                 updated_types.remove(remove_type)
+
+        if not no_validate:
+            updated_types = valid_share_types(
+                fulcra_api=fulcra_api, share_types=updated_types
+            )
 
         # Handle user IDs
         if set_user_ids:

--- a/fulcra_api/cli/share.py
+++ b/fulcra_api/cli/share.py
@@ -70,13 +70,13 @@ def list_incoming(fulcra_api: FulcraAPI):
     "--file",
     "files",
     multiple=True,
-    help="File prefix to share (can be specified multiple times)",
+    help="File to share (can be specified multiple times). Suffix with / to share a directory's contents. Shares the live version only.",
 )
 @click.option(
     "--file-history",
     "file_histories",
     multiple=True,
-    help="File history prefix to share (can be specified multiple times)",
+    help="File history to share, including live version (can be specified multiple times). Suffix with / to share a directory's contents.",
 )
 @click.option(
     "--user-id",
@@ -232,37 +232,37 @@ def leave(fulcra_api: FulcraAPI, share_id: str):
     "--add-file",
     "add_files",
     multiple=True,
-    help="Add a file prefix to the share (can be specified multiple times)",
+    help="Add a file to the share (can be specified multiple times). Suffix with / to share a directory's contents. Shares the live version only.",
 )
 @click.option(
     "--remove-file",
     "remove_files",
     multiple=True,
-    help="Remove file prefix from the share (can be specified multiple times)",
+    help="Remove a live version file or directory from the share (can be specified multiple times)",
 )
 @click.option(
     "--set-file",
     "set_files",
     multiple=True,
-    help="Replace all file prefixes with this list (can be specified multiple times)",
+    help="Replace all live version file and directory shares with this list (can be specified multiple times)",
 )
 @click.option(
     "--add-file-history",
     "add_file_histories",
     multiple=True,
-    help="Add a file historyprefix to the share (can be specified multiple times)",
+    help="Add a file history to the share, including live version (can be specified multiple times). Suffix with / to share a directory's contents.",
 )
 @click.option(
     "--remove-file-history",
     "remove_file_histories",
     multiple=True,
-    help="Remove file history prefix from the share (can be specified multiple times)",
+    help="Remove a file or directory history from the share (can be specified multiple times)",
 )
 @click.option(
     "--set-file-history",
     "set_file_histories",
     multiple=True,
-    help="Replace all file history prefixes with this list (can be specified multiple times)",
+    help="Replace all file and directory history shares with this list (can be specified multiple times)",
 )
 @click.option(
     "--add-user-id",

--- a/fulcra_api/cli/utils.py
+++ b/fulcra_api/cli/utils.py
@@ -217,8 +217,8 @@ def file_share_type(prefix: str, history: bool = False) -> str:
     if not prefix.startswith("/"):
         prefix = f"/{prefix}"
     if history:
-        return f"filehistory:{file}"
-    return f"file:{file}"
+        return f"filehistory:{prefix}"
+    return f"file:{prefix}"
 
 
 def valid_share_types(fulcra_api: FulcraAPI, share_types: list[str]) -> list[str]:
@@ -250,8 +250,7 @@ def valid_share_types(fulcra_api: FulcraAPI, share_types: list[str]) -> list[str
         if invalid_types:
             raise click.ClickException(
                 f"Invalid share type(s): {', '.join(invalid_types)}. "
-                "Use 'fulcra catalog' to see valid data types. "
-                "File paths must start with a slash."
+                "Use 'fulcra catalog' to see valid data types."
             )
     except HTTPError as exc:
         error_body = exc.read().decode("utf-8")

--- a/fulcra_api/cli/utils.py
+++ b/fulcra_api/cli/utils.py
@@ -211,3 +211,50 @@ def time_range(func):
         return func(*args, start_time=start_time, end_time=end_time, **kwargs)
 
     return wrapper
+
+
+def file_share_type(prefix: str, history: bool = False) -> str:
+    if not prefix.startswith("/"):
+        prefix = f"/{prefix}"
+    if history:
+        return f"filehistory:{file}"
+    return f"file:{file}"
+
+
+def validate_share_types(fulcra_api: FulcraAPI, share_types: list[str]) -> list[str]:
+    share_types = sorted(set(share_types))
+    try:
+        catalog = fulcra_api.v1_catalog(fulcra_userid=fulcra_api.get_fulcra_userid())
+        valid_data_type_ids = {item["id"] for item in catalog}
+
+        # TEMPORARY: Allow "calendars" and "calendar_events" even though they're not
+        # in the v1 catalog yet. Remove this special case once they're added to the catalog.
+        temporary_allowed_types = {"calendars", "calendar_events"}
+
+        invalid_types = []
+        for share_type in share_types:
+            if share_type in valid_data_type_ids:
+                continue
+            if share_type in temporary_allowed_types:
+                continue
+
+            parts = share_type.split(":", 1)
+            if len(parts) == 2:
+                match parts[0]:
+                    case "file" | "filehistory":
+                        if parts[1].startswith("/"):
+                            continue
+
+            invalid_types.append(share_type)
+
+        if invalid_types:
+            raise click.ClickException(
+                f"Invalid share type(s): {', '.join(invalid_types)}. "
+                "Use 'fulcra catalog' to see valid data types. "
+                "File paths must start with a slash."
+            )
+    except HTTPError as exc:
+        error_body = exc.read().decode("utf-8")
+        raise click.ClickException(f"Failed to fetch catalog: {exc}\n{error_body}")
+
+    return share_types

--- a/fulcra_api/cli/utils.py
+++ b/fulcra_api/cli/utils.py
@@ -214,6 +214,17 @@ def time_range(func):
 
 
 def file_share_type(prefix: str, history: bool = False) -> str:
+    """
+    Return the share type string for a file or file history path or  prefix.
+
+    Args:
+        prefix: The file or file history path or prefix.
+        history: Whether to share the file history instead of only the live version (default: False).
+
+    Returns:
+        The share type string.
+    """
+
     if not prefix.startswith("/"):
         prefix = f"/{prefix}"
     if history:
@@ -222,6 +233,20 @@ def file_share_type(prefix: str, history: bool = False) -> str:
 
 
 def valid_share_types(fulcra_api: FulcraAPI, share_types: list[str]) -> list[str]:
+    """
+    Validate a list of data type and/or file shares.
+
+    Args:
+        fulcra_api: The FulcraAPI instance.
+        share_types: A list of share types to validate.
+
+    Raises:
+        click.ClickException: If any share type is invalid.
+
+    Returns:
+        A sorted de-duplicated list of valid share types.
+    """
+
     share_types = sorted(set(share_types))
     try:
         catalog = fulcra_api.v1_catalog(fulcra_userid=fulcra_api.get_fulcra_userid())

--- a/fulcra_api/cli/utils.py
+++ b/fulcra_api/cli/utils.py
@@ -221,7 +221,7 @@ def file_share_type(prefix: str, history: bool = False) -> str:
     return f"file:{file}"
 
 
-def validate_share_types(fulcra_api: FulcraAPI, share_types: list[str]) -> list[str]:
+def valid_share_types(fulcra_api: FulcraAPI, share_types: list[str]) -> list[str]:
     share_types = sorted(set(share_types))
     try:
         catalog = fulcra_api.v1_catalog(fulcra_userid=fulcra_api.get_fulcra_userid())

--- a/fulcra_api/core.py
+++ b/fulcra_api/core.py
@@ -2209,11 +2209,19 @@ class FulcraAPI:
 
         return r
 
-    def download_file(self, file_id: str) -> http.client.HTTPResponse:
+    def download_file(
+        self, file_id: str, fulcra_userid: str | None = None
+    ) -> http.client.HTTPResponse:
         """download a file and return the file object"""
 
+        params = {}
+        if fulcra_userid:
+            params["fulcra_userid"] = fulcra_userid
+
         resp = self.fulcra_api(
-            f"/input/v1/file_upload/{file_id}/download", return_http_response=True
+            f"/input/v1/file_upload/{file_id}/download",
+            query=params,
+            return_http_response=True,
         )
 
         return resp

--- a/fulcra_api/core.py
+++ b/fulcra_api/core.py
@@ -2142,7 +2142,12 @@ class FulcraAPI:
         resp = self.fulcra_api(f"/input/v1/file_upload/{version_id}")
         return json.loads(resp)
 
-    def resolve_filepath(self, filepath: str, all_versions: bool = False) -> list[dict]:
+    def resolve_filepath(
+        self,
+        filepath: str,
+        all_versions: bool = False,
+        fulcra_userid: str | None = None,
+    ) -> list[dict]:
         """Take a fully qualified file path and resolve it to the resource definition"""
         p = PurePath(filepath)
 
@@ -2154,9 +2159,13 @@ class FulcraAPI:
         else:
             state = "uploaded"
 
+        params = {"path": str(path), "name": str(name), "state": state}
+        if fulcra_userid is not None:
+            params["fulcra_userid"] = fulcra_userid
+
         resp = self.fulcra_api(
             "/input/v1/file_upload",
-            query={"path": str(path), "name": str(name), "state": state},
+            query=params,
         )
 
         rbody = json.loads(resp)

--- a/fulcra_api/core.py
+++ b/fulcra_api/core.py
@@ -2144,8 +2144,13 @@ class FulcraAPI:
         resp = self.fulcra_api("/input/v1/file_upload", query=params)
         return json.loads(resp)
 
-    def get_file_by_version(self, version_id: str) -> dict:
-        resp = self.fulcra_api(f"/input/v1/file_upload/{version_id}")
+    def get_file_by_version(
+        self, version_id: str, fulcra_userid: str | None = None
+    ) -> dict:
+        params = {}
+        if fulcra_userid:
+            params["fulcra_userid"] = fulcra_userid
+        resp = self.fulcra_api(f"/input/v1/file_upload/{version_id}", query=params)
         return json.loads(resp)
 
     def resolve_filepath(

--- a/fulcra_api/core.py
+++ b/fulcra_api/core.py
@@ -2132,7 +2132,7 @@ class FulcraAPI:
         self, path: str = "/", state: str = "uploaded", fulcra_userid: str | None = None
     ) -> dict:
         params = {"path": path, "state": state}
-        if fulcra_userid is not None:
+        if fulcra_userid:
             params["fulcra_userid"] = fulcra_userid
 
         resp = self.fulcra_api("/input/v1/file_upload", query=params)
@@ -2160,7 +2160,7 @@ class FulcraAPI:
             state = "uploaded"
 
         params = {"path": str(path), "name": str(name), "state": state}
-        if fulcra_userid is not None:
+        if fulcra_userid:
             params["fulcra_userid"] = fulcra_userid
 
         resp = self.fulcra_api(

--- a/fulcra_api/core.py
+++ b/fulcra_api/core.py
@@ -2129,11 +2129,17 @@ class FulcraAPI:
     #
 
     def list_files(
-        self, path: str = "/", state: str = "uploaded", fulcra_userid: str | None = None
+        self,
+        path: str = "/",
+        state: str = "uploaded",
+        fulcra_userid: str | None = None,
+        base_name: str | None = None,
     ) -> dict:
         params = {"path": path, "state": state}
         if fulcra_userid:
             params["fulcra_userid"] = fulcra_userid
+        if base_name:
+            params["name"] = base_name
 
         resp = self.fulcra_api("/input/v1/file_upload", query=params)
         return json.loads(resp)

--- a/fulcra_api/core.py
+++ b/fulcra_api/core.py
@@ -2128,10 +2128,14 @@ class FulcraAPI:
     # File functionality
     #
 
-    def list_files(self, path: str = "/", state: str = "uploaded") -> dict:
-        resp = self.fulcra_api(
-            "/input/v1/file_upload", query={"path": path, "state": state}
-        )
+    def list_files(
+        self, path: str = "/", state: str = "uploaded", fulcra_userid: str | None = None
+    ) -> dict:
+        params = {"path": path, "state": state}
+        if fulcra_userid is not None:
+            params["fulcra_userid"] = fulcra_userid
+
+        resp = self.fulcra_api("/input/v1/file_upload", query=params)
         return json.loads(resp)
 
     def get_file_by_version(self, version_id: str) -> dict:

--- a/fulcra_api/core.py
+++ b/fulcra_api/core.py
@@ -2153,6 +2153,7 @@ class FulcraAPI:
         filepath: str,
         all_versions: bool = False,
         fulcra_userid: str | None = None,
+        include_deleted: bool = False,
     ) -> list[dict]:
         """Take a fully qualified file path and resolve it to the resource definition"""
         p = PurePath(filepath)
@@ -2164,6 +2165,9 @@ class FulcraAPI:
             state = "uploaded,archived"
         else:
             state = "uploaded"
+
+        if include_deleted:
+            state += ",deleted"
 
         params = {"path": str(path), "name": str(name), "state": state}
         if fulcra_userid:
@@ -2180,7 +2184,9 @@ class FulcraAPI:
             files = sorted(rbody["files"], key=lambda d: d["uploaded_at"], reverse=True)
 
             # If there's no files or current versions, it doesn't exist
-            if len(files) == 0 or files[0]["state"] != "uploaded":
+            if (
+                len(files) == 0 or files[0]["state"] != "uploaded"
+            ) and not include_deleted:
                 raise Exception(f"File not found in Fulcra: {filepath}")
         else:
             files = rbody["files"]


### PR DESCRIPTION
Adds `--file` and `--file-history` as well as `--no-validate` options to share creation and update commands, and moves shared type validation into the `utils.py`. This validation is currently only used by the `share` command, but may later be leveraged for groups and sessions as well.

Adds `--user-id`, `--base-name`, `--include-deleted`, and `--version` options to file commands to permit users to list, stat, and download shared files in a granular way compatible with file or directory shares, and live version or history shares. Updates the core file listing, resolution, and download functions to support the additional parameters.

- depends on https://github.com/fulcradynamics/input-service/pull/34
- depends on https://github.com/fulcradynamics/user-service/pull/111
- design doc: https://app.nuclino.com/Fulcra-Dynamics/Engineering-Wiki/Design-File-Sharing-351a1dac-3801-457a-a6fe-a0e7aed67dbd